### PR TITLE
Change the license of init.d_script_raw to GPL version 3 or later

### DIFF
--- a/scripts/startup/init.d_script_raw
+++ b/scripts/startup/init.d_script_raw
@@ -4,19 +4,18 @@
 #
 # Copyright (c) 2009-2021 Steffen Wendzel, https://www.wendzel.de
 #
-# This is free software; you may redistribute it and/or modify
-# it under the terms of the GNU General Public License as
-# published by the Free Software Foundation; either version 2,
-# or (at your option) any later version.
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
 #
-# This is distributed in the hope that it will be useful, but
-# WITHOUT ANY WARRANTY; without even the implied warranty of
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
-# You should have received a copy of the GNU General Public License with
-# this software;  if not, write to the Free Software Foundation, Inc.,
-# 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 DAEMON=REPLACETHIS_WITH_DAEMONPATH
 


### PR DESCRIPTION
Change the license of init.d_script_raw from GPL version 2 or later to GPL version 3 or later for consistency with the rest of the project. Adjusted the wording for consistency with the standard license wording and the rest of the project.