### PR TITLE
Fix mysql_db_struct.sql

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -41,7 +41,15 @@ FIXES:
    is no longer truncated and the hash is correctly converted to the
    hexadecimal representation. User databases need to be re-generated
    using wendzelnntpadm, see `upgrade' instructions in the documentation.
-
+ - Fix the SQL script mysql_db_struct.sql
+   - Increase the size of the password column in the users table to 64 to
+     be big enough for the password hashes
+   - Use unique names for the foreign key constraints to avoid the error
+     (errno: 121 "Duplicate key on write or update")
+   - change the type of the of the header column in the postings table
+     from VARCHAR to TEXT to stay under the limit of 16383 characters per
+     column on databases which use the charset utfmb4 with 4 bytes per
+     character
 MISC:
  - Applied NetBSD pkgsrc patch for err feature and for lexer/parser
    functions from Michael Baeuerle; thx for that!

--- a/database/mysql_db_struct.sql
+++ b/database/mysql_db_struct.sql
@@ -23,7 +23,7 @@ CREATE TABLE postings (
    `newsgroups` VARCHAR(2048),
    `subject` VARCHAR(2048),
    `lines` VARCHAR(10),
-   `header` VARCHAR(20000),
+   `header` TEXT,
    INDEX(`msgid`),
    PRIMARY KEY(`msgid`)
  ) ENGINE=INNODB;
@@ -38,14 +38,14 @@ CREATE TABLE ngposts (
    PRIMARY KEY(`msgid`, `ng`),
    INDEX `I_msgid` (`msgid`),
    INDEX `I_ng` (`ng`),
-   FOREIGN KEY `FK_msgid` (`msgid`) REFERENCES `postings` (`msgid`) ON DELETE CASCADE,
-   FOREIGN KEY `FK_ng` (`ng`) REFERENCES `newsgroups` (`name`) ON DELETE CASCADE
+   FOREIGN KEY `FK_ngposts_msgid` (`msgid`) REFERENCES `postings` (`msgid`) ON DELETE CASCADE,
+   FOREIGN KEY `FK_ngposts_ng` (`ng`) REFERENCES `newsgroups` (`name`) ON DELETE CASCADE
  ) ENGINE=INNODB;
 
 -- Authentification (as well as ACL)
 CREATE TABLE users (
    `name` VARCHAR(50),
-   `password` VARCHAR(50),
+   `password` VARCHAR(64),
    INDEX(`name`),
    PRIMARY KEY(`name`)
 ) ENGINE=INNODB;
@@ -67,8 +67,8 @@ CREATE TABLE users2roles (
    PRIMARY KEY(`username`, `role`),
    INDEX(`username`),
    INDEX(`role`),
-   FOREIGN KEY `FK_usr` (`username`) REFERENCES `users` (`name`) ON DELETE CASCADE,
-   FOREIGN KEY `FK_rle` (`role`) REFERENCES `roles` (`role`) ON DELETE CASCADE
+   FOREIGN KEY `FK_users2roles_usr` (`username`) REFERENCES `users` (`name`) ON DELETE CASCADE,
+   FOREIGN KEY `FK_users2roles_rle` (`role`) REFERENCES `roles` (`role`) ON DELETE CASCADE
  ) ENGINE=INNODB;
 
 -- User 2 Newsgroup
@@ -78,8 +78,8 @@ CREATE TABLE acl_users (
    PRIMARY KEY(`username`, `ng`),
    INDEX(`username`),
    INDEX(`ng`),
-   FOREIGN KEY `FK_usr` (`username`) REFERENCES `users` (`name`) ON DELETE CASCADE,
-   FOREIGN KEY `FK_ng` (`ng`) REFERENCES `newsgroups` (`name`) ON DELETE CASCADE
+   FOREIGN KEY `FK_acl_users_usr` (`username`) REFERENCES `users` (`name`) ON DELETE CASCADE,
+   FOREIGN KEY `FK_acl_users_ng` (`ng`) REFERENCES `newsgroups` (`name`) ON DELETE CASCADE
  ) ENGINE=INNODB;
 
 -- Roles 2 Newsgroup
@@ -89,8 +89,8 @@ CREATE TABLE acl_roles (
    INDEX(`role`),
    INDEX(`ng`),
    PRIMARY KEY(`role`, `ng`),
-   FOREIGN KEY `FK_ng` (`ng`) REFERENCES `newsgroups` (`name`) ON DELETE CASCADE,
-   FOREIGN KEY `FK_rle` (`role`) REFERENCES `roles` (`role`) ON DELETE CASCADE
+   FOREIGN KEY `FK_acl_roles_ng` (`ng`) REFERENCES `newsgroups` (`name`) ON DELETE CASCADE,
+   FOREIGN KEY `FK_acl_roles_rle` (`role`) REFERENCES `roles` (`role`) ON DELETE CASCADE
  ) ENGINE=INNODB;
 
 -- Check:


### PR DESCRIPTION
- Change the type of the header column in the postings table from VARCHAR(20000) to TEXT to avoid the ERROR 1074 (column length too big). The maximum column length is 16383 for a current mariadb (11.8) with the default charset (utfmb8)
- Extend the length of the password column in the users table from 50 to 64 characters because the password hash is 64 characters long.
- Use unique names for the foreign key constraints to avoid the error (errno: 121 "Duplicate key on write or update")