### PR TITLE
Fix input buffer sanitization

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -1750,7 +1750,7 @@ do_server(void *socket_info_ptr)
 			/* make the buffer more secure before going on */
 			/* 1. remove trailing \r\n by replacing \r with \0 */
 			for (i = (strlen(recvbuf) - 1); i > 0; i--) {
-				if (recvbuf[i] == '\r' || recvbuf[i] == '\n') {
+				if (recvbuf[i] == '\r') {
 					recvbuf[i] = '\0';
 					i = 0; /* = break */
 				}


### PR DESCRIPTION
This reverts a change from commit dac2ee4f causing some inputs to be processed incorrectly when using a mysql database. \r would not be removed anymore for inputs ending with \r\n because the code would only remove the \n leaving the \r in place. The function mysql_real_escape_string would then replace the \r with \\r causing some nntp commands to be processed incorrectly. For example the input "group x\r\n" would be transformed to "group x\r" which would be transformed to "group x\\r". This would result in searching the group with the name "x\\r" instead of "x".

I don't now the reason for this change in commit dac2ee4f but could not observe any negative side effects from reverting the change. I ran the TLS-tests from the directory unittesting/tls-testing successfully on various Linux and BSD distributions.

I did not including an entry in the changelog because this bug only affects the not yet released version 2.2.