### PR TITLE
Terminate the process when receiving terminating signals

### DIFF
--- a/src/globals.c
+++ b/src/globals.c
@@ -218,4 +218,10 @@ void signal_action_handler (int signal_number, siginfo_t *sigstru, void *dum) {
    }
    sprintf(line,"SIGNAL Received Signal Name: %s  Nr. %d  Error. %d  Code %d ",sname,signal_number,sigstru->si_errno,sigstru->si_code);
    DO_SYSL(line);
+
+   if (rec_sigterm == 1) {
+       // reraise the signal to the default signal handler which sets the return status and terminates the process
+       signal(signal_number, SIG_DFL);
+       raise(signal_number);
+   }
 }


### PR DESCRIPTION
Reraise the signal for terminating signals (SIGTERM, SIGINT, SIGQUIT) to the default signal handler which sets the return status and terminates the process.

The wendzelnntpd process can't be terminated with the signals SIGTERM, SIGINT and SIGQUIT without this change. This means that the process can't be terminated by pressing ctrl + c in the console or by killing the process with "kill" without explicitly sending the signal SIGTERM (the default signal when calling kill is SIGKILL). The latter also prevents the stopping or restarting of wendzelnntpd with the init.d_script.

I did not add an entry to the changelog because this bug only affects the not yet released version 2.2.