### PR TITLE
Fix article selection for empty groups and the xhdr command when using a postgresql database

### DIFF
--- a/src/db_postgres.c
+++ b/src/db_postgres.c
@@ -511,9 +511,9 @@ db_postgres_xhdr(server_cb_inf *inf, short message_id_flg, int xhdr, char *artic
 	snprintf(min_s, 64-1, "%d", min);
 	snprintf(max_s, 64-1, "%d", max);
 
-	const char* paramValues[3];
-	int paramLengths[3];
-	int paramFormats[] = {0,0,0};
+	const char* paramValues[4];
+	int paramLengths[4];
+	int paramFormats[] = {0,0,0,0};
 	int resultFormat = 0;
 
 
@@ -558,12 +558,15 @@ db_postgres_xhdr(server_cb_inf *inf, short message_id_flg, int xhdr, char *artic
 	    param++;
 	} else {
 	    sql_cmd =
-		"select * from xhdr_get($1, 'test.g1', null, $2, $3)";
-	    paramValues[1] = min_s;
+		"select * from xhdr_get($1, $2, null, $3, $4)";
+	    paramValues[1] = inf->servinf->selected_group;
 	    paramLengths[1] = strlen(paramValues[1]);
 	    param++;
-	    paramValues[2] = max_s;
+	    paramValues[2] = min_s;
 	    paramLengths[2] = strlen(paramValues[2]);
+	    param++;
+	    paramValues[3] = max_s;
+	    paramLengths[3] = strlen(paramValues[3]);
 	    param++;
 	}
 

--- a/src/db_postgres.c
+++ b/src/db_postgres.c
@@ -811,7 +811,10 @@ db_postgres_group_cb_set_first_article_in_group(server_cb_inf *inf)
 	}
 
 	if (PQntuples(res) == 1) {
-	    inf->servinf->selected_article = strdup(PQgetvalue(res, 0, 0));
+		char *postnum = PQgetvalue(res, 0, 0);
+		if (postnum[0] != '\0') {
+			inf->servinf->selected_article = strdup(postnum);
+		}
 	}
 	PQclear(res);
 }


### PR DESCRIPTION
This PR fixes two bugs in the experimental postgres database support:

- the variable selected_article wasn't set to an empty string when there are no articles in the selected group instead of NULL like it's done for the other databases. This causes errors and closed connections when processing other nntp commands like "article" which try to access the selected_article. 
- When the xhdr command is used without specifying  a messageid (e.g. "xhdr subject") then the articles will always be searched in the group with the name "test.g1" instead of the selected_group.

I did not add an entry to the changelog because this bugs only affect the not yet released version 2.2.