### PR TITLE
Fix bufferoverflows

### DIFF
--- a/src/hash.c
+++ b/src/hash.c
@@ -75,7 +75,7 @@ char *get_sha256_hash_from_str(char *username /* don't free! */, char *password)
 	mhash_deinit(td, hash_raw);
 
 	for (i = 0; i < SHA256_LEN/2; i++) {
-		snprintf(hash + (2 * i), 4, "%.2x", hash_raw[i]);
+		snprintf(hash + (2 * i), 3, "%.2x", hash_raw[i]);
 	}
 	bzero_and_free_sensitive_strings((char*) hash_raw, strs_plus_salt, NULL); /* overwrite with zeros */
 	return hash;

--- a/src/server.c
+++ b/src/server.c
@@ -1295,7 +1295,7 @@ docmd_post(server_cb_inf *inf)
 				kill_thread(inf);
 				/* NOTREACHED */
 			}
-			snprintf(message_id, MAX_IDNUM_LEN+3+strlen(addr), "%s%s>", newid, hostinfo->h_name);
+			snprintf(message_id, MAX_IDNUM_LEN+3+strlen(hostinfo->h_name), "%s%s>", newid, hostinfo->h_name);
 			//free(hostinfo);
 		}
 		free(addr);/* NEW */


### PR DESCRIPTION
This PR fixes 2 buffer overflows:

- The size of the `hash` buffer in get_sha256_hash_from_str is 65 bytes (SHA256_LEN + 1). `i` is 31 (SHA256_LEN / 2 - 1) in the last iteration of the loop. The snprintf function gets called with the pointer `hash + (2 * i)`, so the rest of the buffer is only 65 - 2 * 31 = 3 bytes big. This is not enough because the second parameter which is passed to snprintf  (the maximum number of characters) is set to 4 and snprintf requires to buffer to be as least as big as the maximum number of characters from the second parameter. Lowering the second parameter from 4 to 3 fixes this issue. It's save to lower this parameter to 3, because 3 characters are enough here (2 characters are added to the hash + 1 terminating null character).
- In docmd_post when calculating the message_id, the wrong maximum number of bytes is passed to the snprintf-function. `MAX_IDNUM_LEN+3+strlen(addr)` is used to calculate the maximum number of bytes which depends of the length of `addr`. But the last argument passed to snprintf is `hostinfo->h_name` which can be bigger than `addr`, causing a buffer overflow. So the maximum number of bytes should be calculated by the length of `hostinfo->h_name` instead of `addr`.