### PR TITLE
Switch license of the file wendzelnntpd.SlackBuild to GPLv3

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -151,6 +151,7 @@ MISC:
    different architectures.
  - Improve the detection of root privileges in the script
    create_certificate.
+ - Switch license of the file wendzelnntpd.SlackBuild to GPLv3
 
 2.1.3-stable "Friedrichroda" : 17-Apr-2021:
  As usual, every new release gets named after a nice travel location.

--- a/packages/slackware/wendzelnntpd.SlackBuild
+++ b/packages/slackware/wendzelnntpd.SlackBuild
@@ -5,22 +5,18 @@
 # Copyright 2021 Steffen Wendzel, https://www.wendzel.de
 # All rights reserved.
 #
-# Redistribution and use of this script, with or without modification, is
-# permitted provided that the following conditions are met:
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
 #
-# 1. Redistributions of this script must retain the above copyright
-#    notice, this list of conditions and the following disclaimer.
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
 #
-#  THIS SOFTWARE IS PROVIDED BY THE AUTHOR "AS IS" AND ANY EXPRESS OR IMPLIED
-#  WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
-#  MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO
-#  EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-#  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
-#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
-#  OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
-#  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
-#  OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
-#  ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 # This script was written using the one from slackbuilds.org as a reference.
 # Thanks to Patrick Volkerding and Adis Nezirovic for the original work.


### PR DESCRIPTION
Change the license of wendzelnntpd.SlackBuild to GPL version 3 or later for consistency with the rest of the project as discussed by mail.
According to the copyright header and the git history Steffen Wendzel is the only author of the file, so as far as I know, a license change should be possible with your(@cdpxe) approval.