### PR TITLE
Increase timeout in the expect tests to avoid failures in the github workflow

### DIFF
--- a/unittesting/tests/nntp-article-test.exp
+++ b/unittesting/tests/nntp-article-test.exp
@@ -1,4 +1,4 @@
-set timeout 2
+set timeout 5
 
 send_user "=== Test article command ===\n"
 

--- a/unittesting/tests/nntp-authinfo-test.exp
+++ b/unittesting/tests/nntp-authinfo-test.exp
@@ -1,4 +1,4 @@
-set timeout 2
+set timeout 5
 
 send_user "=== Test authinfo command ===\n"
 

--- a/unittesting/tests/nntp-body-test.exp
+++ b/unittesting/tests/nntp-body-test.exp
@@ -1,4 +1,4 @@
-set timeout 2
+set timeout 5
 
 send_user "=== Test body command ===\n"
 

--- a/unittesting/tests/nntp-capabilities-test.exp
+++ b/unittesting/tests/nntp-capabilities-test.exp
@@ -1,4 +1,4 @@
-set timeout 2
+set timeout 5
 
 send_user "=== Test capabilities command ===\n"
 

--- a/unittesting/tests/nntp-date-test.exp
+++ b/unittesting/tests/nntp-date-test.exp
@@ -1,4 +1,4 @@
-set timeout 2
+set timeout 5
 
 send_user "=== Test date command ===\n"
 

--- a/unittesting/tests/nntp-group-test.exp
+++ b/unittesting/tests/nntp-group-test.exp
@@ -1,4 +1,4 @@
-set timeout 2
+set timeout 5
 
 send_user "=== Test group command ===\n"
 

--- a/unittesting/tests/nntp-head-test.exp
+++ b/unittesting/tests/nntp-head-test.exp
@@ -1,4 +1,4 @@
-set timeout 2
+set timeout 5
 
 send_user "=== Test head command ===\n"
 

--- a/unittesting/tests/nntp-help-test.exp
+++ b/unittesting/tests/nntp-help-test.exp
@@ -1,4 +1,4 @@
-set timeout 2
+set timeout 5
 
 send_user "=== Test help command ===\n"
 

--- a/unittesting/tests/nntp-initial-connection-test.exp
+++ b/unittesting/tests/nntp-initial-connection-test.exp
@@ -1,4 +1,4 @@
-set timeout 2
+set timeout 5
 
 send_user "=== Test initial connection ===\n"
 

--- a/unittesting/tests/nntp-list-newsgroups-test.exp
+++ b/unittesting/tests/nntp-list-newsgroups-test.exp
@@ -1,4 +1,4 @@
-set timeout 2
+set timeout 5
 
 send_user "=== Test list newsgroups command ===\n"
 

--- a/unittesting/tests/nntp-list-overview.fmt-test.exp
+++ b/unittesting/tests/nntp-list-overview.fmt-test.exp
@@ -1,4 +1,4 @@
-set timeout 2
+set timeout 5
 
 send_user "=== Test list overview.fmt command ===\n"
 

--- a/unittesting/tests/nntp-list-test.exp
+++ b/unittesting/tests/nntp-list-test.exp
@@ -1,4 +1,4 @@
-set timeout 2
+set timeout 5
 
 send_user "=== Test list command ===\n"
 

--- a/unittesting/tests/nntp-listgroup-test.exp
+++ b/unittesting/tests/nntp-listgroup-test.exp
@@ -1,4 +1,4 @@
-set timeout 2
+set timeout 5
 
 send_user "=== Test listgroup command ===\n"
 

--- a/unittesting/tests/nntp-mode-reader-test.exp
+++ b/unittesting/tests/nntp-mode-reader-test.exp
@@ -1,4 +1,4 @@
-set timeout 2
+set timeout 5
 
 send_user "=== Test mode reader command ===\n"
 

--- a/unittesting/tests/nntp-mutual-tls-fails-test.exp
+++ b/unittesting/tests/nntp-mutual-tls-fails-test.exp
@@ -1,4 +1,4 @@
-set timeout 2
+set timeout 5
 
 send_user "=== Test with active TLS via extra port, with mutual TLS but without client certificate ===\n"
 

--- a/unittesting/tests/nntp-mutual-tls-test.exp
+++ b/unittesting/tests/nntp-mutual-tls-test.exp
@@ -1,4 +1,4 @@
-set timeout 2
+set timeout 5
 
 send_user "=== Test with active TLS via extra port, with mutual TLS and client certificate ===\n"
 

--- a/unittesting/tests/nntp-post-test.exp
+++ b/unittesting/tests/nntp-post-test.exp
@@ -1,4 +1,4 @@
-set timeout 2
+set timeout 5
 
 send_user "=== Test post command ===\n"
 

--- a/unittesting/tests/nntp-quit-test.exp
+++ b/unittesting/tests/nntp-quit-test.exp
@@ -1,4 +1,4 @@
-set timeout 2
+set timeout 5
 
 send_user "=== Test quit command ===\n"
 

--- a/unittesting/tests/nntp-starttls-test.exp
+++ b/unittesting/tests/nntp-starttls-test.exp
@@ -1,4 +1,4 @@
-set timeout 2
+set timeout 5
 
 send_user "=== Test with activated TLS via STARTTLS ===\n"
 

--- a/unittesting/tests/nntp-stat-test.exp
+++ b/unittesting/tests/nntp-stat-test.exp
@@ -1,4 +1,4 @@
-set timeout 2
+set timeout 5
 
 send_user "=== Test stat command ===\n"
 

--- a/unittesting/tests/nntp-tls-port-test.exp
+++ b/unittesting/tests/nntp-tls-port-test.exp
@@ -1,4 +1,4 @@
-set timeout 2
+set timeout 5
 
 send_user "=== Test with active TLS via extra port ===\n"
 

--- a/unittesting/tests/nntp-xgtitle-test.exp
+++ b/unittesting/tests/nntp-xgtitle-test.exp
@@ -1,4 +1,4 @@
-set timeout 2
+set timeout 5
 
 send_user "=== Test xgtitle command ===\n"
 

--- a/unittesting/tests/nntp-xhdr-test.exp
+++ b/unittesting/tests/nntp-xhdr-test.exp
@@ -1,4 +1,4 @@
-set timeout 2
+set timeout 5
 
 send_user "=== Test xhdr command ===\n"
 

--- a/unittesting/tests/nntp-xover-test.exp
+++ b/unittesting/tests/nntp-xover-test.exp
@@ -1,4 +1,4 @@
-set timeout 2
+set timeout 5
 
 send_user "=== Test xover command ===\n"
 

--- a/unittesting/tests/special/nntp-acl-test.exp
+++ b/unittesting/tests/special/nntp-acl-test.exp
@@ -1,4 +1,4 @@
-set timeout 2
+set timeout 5
 
 send_user "=== Test acl feature ===\n"
 

--- a/unittesting/tests/special/nntp-mandatory-tls-test.exp
+++ b/unittesting/tests/special/nntp-mandatory-tls-test.exp
@@ -1,4 +1,4 @@
-set timeout 2
+set timeout 5
 
 send_user "=== Test for mandatory TLS on non-encrypted NNTP port ===\n"
 


### PR DESCRIPTION
Avoid tests failures due to timeouts like in https://github.com/cdpxe/WendzelNNTPd/actions/runs/17740542486/job/50413162664