### PR TITLE
Create TLS by default, rearrange config files and improve create_certificate

### DIFF
--- a/.github/workflows/build-tests.yml
+++ b/.github/workflows/build-tests.yml
@@ -112,13 +112,11 @@ jobs:
         run: docker exec testcontainer bash -c "make"
       - name: make install
         run: docker exec testcontainer bash -c "make install"
-      - name: Setup ssl certificates
-        run: docker exec testcontainer bash -c "./create_certificate --environment local"
       - name: Initialize test data
         run: >
           docker exec testcontainer bash -c "cd unittesting
           && ./initialize_db.sh
-          && cp test-files/wendzelnntpd.conf /usr/local/etc/"
+          && cp test-files/wendzelnntpd.conf /usr/local/etc/wendzelnntpd/"
       - name: Test wendzelnntpadm
         run: docker exec testcontainer bash -c "cd unittesting && ./test_wendzelnntpadm.sh"
       - name: Reinitialize database
@@ -129,8 +127,8 @@ jobs:
         run: >
           cd unittesting
           && mkdir tmp
-          && docker cp testcontainer:/usr/local/etc/ssl/ca.crt tmp/ca-self.crt
-          && docker cp testcontainer:/usr/local/etc/ssl/ca-key.pem tmp/ca-self.key
+          && docker cp testcontainer:/usr/local/etc/wendzelnntpd/ssl/ca.crt tmp/ca-self.crt
+          && docker cp testcontainer:/usr/local/etc/wendzelnntpd/ssl/ca-key.pem tmp/ca-self.key
       - name: Create client cert for mutual tls tests
         run: cd unittesting && ./create-client-cert.sh
       - name: get container ipv4
@@ -151,16 +149,16 @@ jobs:
         run: cd unittesting && nntp_address=${{ env.ipv6 }} ./run.sh
       - name: Enable mandatory tls
         run: >
-          docker exec testcontainer bash -c "echo \"tls-is-mandatory\" >> /usr/local/etc/wendzelnntpd.conf
+          docker exec testcontainer bash -c "echo \"tls-is-mandatory\" >> /usr/local/etc/wendzelnntpd/wendzelnntpd.conf
           && pkill -9 wendzelnntpd && wendzelnntpd -d"
       - name: expect test for mandatory tls
         run: cd unittesting && nntp_address=${{ env.ipv4 }} expect tests/special/nntp-mandatory-tls-test.exp
       - name: reset config and enable acl
         run: >
           docker exec testcontainer bash -c "cd unittesting
-          && cp test-files/wendzelnntpd.conf /usr/local/etc/
-          && echo \"use-authentication\" >> /usr/local/etc/wendzelnntpd.conf
-          && echo \"use-acl\" >> /usr/local/etc/wendzelnntpd.conf"
+          && cp test-files/wendzelnntpd.conf /usr/local/etc/wendzelnntpd/
+          && echo \"use-authentication\" >> /usr/local/etc/wendzelnntpd/wendzelnntpd.conf
+          && echo \"use-acl\" >> /usr/local/etc/wendzelnntpd/wendzelnntpd.conf"
       - name: restart wendzelnntpd
         run: docker exec testcontainer bash -c "pkill -9 wendzelnntpd && wendzelnntpd -d"
       - name: expect test for acl
@@ -168,9 +166,9 @@ jobs:
       - name: reset config and switch to mysql database
         run: >
           docker exec testcontainer bash -c "cd unittesting
-          && cp test-files/wendzelnntpd.conf /usr/local/etc/
-          && sed -i 's/^database-engine sqlite3$/database-engine mysql/' /usr/local/etc/wendzelnntpd.conf
-          && sed -i 's/^database-server 127.0.0.1$/database-server mariadb/' /usr/local/etc/wendzelnntpd.conf"
+          && cp test-files/wendzelnntpd.conf /usr/local/etc/wendzelnntpd/
+          && sed -i 's/^database-engine sqlite3$/database-engine mysql/' /usr/local/etc/wendzelnntpd/wendzelnntpd.conf
+          && sed -i 's/^database-server 127.0.0.1$/database-server mariadb/' /usr/local/etc/wendzelnntpd/wendzelnntpd.conf"
       - name: Initialize test data in mariadb
         run: >
           mysql --host=127.0.0.1 --user=root --password=rootpass --execute
@@ -187,9 +185,9 @@ jobs:
       - name: reset config and switch to postgresql database
         run: >
           docker exec testcontainer bash -c "cd unittesting
-          && cp test-files/wendzelnntpd.conf /usr/local/etc/
-          && sed -i 's/^database-engine sqlite3$/database-engine postgres/' /usr/local/etc/wendzelnntpd.conf
-          && sed -i 's/^database-server 127.0.0.1$/database-server postgres/' /usr/local/etc/wendzelnntpd.conf"
+          && cp test-files/wendzelnntpd.conf /usr/local/etc/wendzelnntpd/
+          && sed -i 's/^database-engine sqlite3$/database-engine postgres/' /usr/local/etc/wendzelnntpd/wendzelnntpd.conf
+          && sed -i 's/^database-server 127.0.0.1$/database-server postgres/' /usr/local/etc/wendzelnntpd/wendzelnntpd.conf"
       - name: Initialize test data in postgresql database
         run: >
           psql postgresql://testuser:testpass@127.0.0.1:5432/wendzelnntpd
@@ -313,15 +311,12 @@ jobs:
         if: ${{ matrix.distribution == 'netbsd' }}
       - name: Link vm shell script
         run: ln -s /home/runner/.local/bin/${{ matrix.distribution }} /home/runner/.local/bin/vm
-      - name: Setup ssl certificates
-        shell: vm {0}
-        run: cd $GITHUB_WORKSPACE && bash ./create_certificate --environment local
       - name: Initialize test data
         shell: vm {0}
         run: >
           cd $GITHUB_WORKSPACE/unittesting
           && bash ./initialize_db.sh
-          && cp test-files/wendzelnntpd.conf /usr/local/etc/
+          && cp test-files/wendzelnntpd.conf /usr/local/etc/wendzelnntpd/
       - name: Test wendzelnntpadm
         shell: vm {0}
         run: cd $GITHUB_WORKSPACE/unittesting && PATH=/usr/local/sbin:$PATH ./test_wendzelnntpadm.sh
@@ -335,8 +330,8 @@ jobs:
         run: >
           cd unittesting
           && mkdir tmp
-          && scp ${{ matrix.distribution }}:/usr/local/etc/ssl/ca.crt tmp/ca-self.crt
-          && scp ${{ matrix.distribution }}:/usr/local/etc/ssl/ca-key.pem tmp/ca-self.key
+          && scp ${{ matrix.distribution }}:/usr/local/etc/wendzelnntpd/ssl/ca.crt tmp/ca-self.crt
+          && scp ${{ matrix.distribution }}:/usr/local/etc/wendzelnntpd/ssl/ca-key.pem tmp/ca-self.key
       - name: Create client cert for mutual tls tests
         run: cd unittesting && ./create-client-cert.sh
       - name: get vm ipv4
@@ -358,7 +353,7 @@ jobs:
       - name: Enable mandatory tls
         shell: vm {0}
         run: >
-          echo \"tls-is-mandatory\" >> /usr/local/etc/wendzelnntpd.conf
+          echo \"tls-is-mandatory\" >> /usr/local/etc/wendzelnntpd/wendzelnntpd.conf
           && pkill -9 wendzelnntpd && /usr/local/sbin/wendzelnntpd -d > /dev/null 2> /dev/null &
       - name: expect test for mandatory tls
         run: cd unittesting && nntp_address=${{ env.ipv4 }} expect tests/special/nntp-mandatory-tls-test.exp
@@ -366,9 +361,9 @@ jobs:
         shell: vm {0}
         run: >
           cd $GITHUB_WORKSPACE/unittesting
-          && cp test-files/wendzelnntpd.conf /usr/local/etc/
-          && echo \"use-authentication\" >> /usr/local/etc/wendzelnntpd.conf
-          && echo \"use-acl\" >> /usr/local/etc/wendzelnntpd.conf
+          && cp test-files/wendzelnntpd.conf /usr/local/etc/wendzelnntpd/
+          && echo \"use-authentication\" >> /usr/local/etc/wendzelnntpd/wendzelnntpd.conf
+          && echo \"use-acl\" >> /usr/local/etc/wendzelnntpd/wendzelnntpd.conf
       - name: restart wendzelnntpd
         shell: vm {0}
         run: pkill -9 wendzelnntpd && /usr/local/sbin/wendzelnntpd -d > /dev/null 2> /dev/null &
@@ -378,11 +373,11 @@ jobs:
         shell: vm {0}
         run: >
           cd $GITHUB_WORKSPACE/unittesting
-          && cp test-files/wendzelnntpd.conf /usr/local/etc/
-          && sed 's/^database-engine sqlite3$/database-engine mysql/' /usr/local/etc/wendzelnntpd.conf > temp
-          && mv temp /usr/local/etc/wendzelnntpd.conf
-          && sed 's/^database-server 127\.0\.0\.1$/database-server 192\.168\.122\.1/' /usr/local/etc/wendzelnntpd.conf > temp
-          && mv temp /usr/local/etc/wendzelnntpd.conf
+          && cp test-files/wendzelnntpd.conf /usr/local/etc/wendzelnntpd/
+          && sed 's/^database-engine sqlite3$/database-engine mysql/' /usr/local/etc/wendzelnntpd/wendzelnntpd.conf > temp
+          && mv temp /usr/local/etc/wendzelnntpd/wendzelnntpd.conf
+          && sed 's/^database-server 127\.0\.0\.1$/database-server 192\.168\.122\.1/' /usr/local/etc/wendzelnntpd/wendzelnntpd.conf > temp
+          && mv temp /usr/local/etc/wendzelnntpd/wendzelnntpd.conf
       - name: Initialize test data in mariadb
         run: >
           mysql --host=127.0.0.1 --user=root --password=rootpass --execute
@@ -401,11 +396,11 @@ jobs:
         shell: vm {0}
         run: >
           cd $GITHUB_WORKSPACE/unittesting
-          && cp test-files/wendzelnntpd.conf /usr/local/etc/
-          && sed 's/^database-engine sqlite3$/database-engine postgres/' /usr/local/etc/wendzelnntpd.conf > temp
-          && mv temp /usr/local/etc/wendzelnntpd.conf
-          && sed 's/^database-server 127\.0\.0\.1$/database-server 192\.168\.122\.1/' /usr/local/etc/wendzelnntpd.conf > temp
-          && mv temp /usr/local/etc/wendzelnntpd.conf
+          && cp test-files/wendzelnntpd.conf /usr/local/etc/wendzelnntpd/
+          && sed 's/^database-engine sqlite3$/database-engine postgres/' /usr/local/etc/wendzelnntpd/wendzelnntpd.conf > temp
+          && mv temp /usr/local/etc/wendzelnntpd/wendzelnntpd.conf
+          && sed 's/^database-server 127\.0\.0\.1$/database-server 192\.168\.122\.1/' /usr/local/etc/wendzelnntpd/wendzelnntpd.conf > temp
+          && mv temp /usr/local/etc/wendzelnntpd/wendzelnntpd.conf
       - name: Initialize test data in postgresql database
         run: >
           psql postgresql://testuser:testpass@127.0.0.1:5432/wendzelnntpd

--- a/.github/workflows/build-tests.yml
+++ b/.github/workflows/build-tests.yml
@@ -269,7 +269,6 @@ jobs:
             pkg_add mariadb-client
             pkg_add postgresql-client
           run: |
-            cp unittesting/test-files/openssl.cnf /etc/ssl/openssl.cnf
             ./configure --enable-postgres CPPFLAGS="-I/usr/local/include" LDFLAGS="-L/usr/local/lib"
             make
             make install
@@ -307,7 +306,6 @@ jobs:
             /usr/sbin/pkg_add mariadb-client
             /usr/sbin/pkg_add postgresql17-client
           run: |
-            cp unittesting/test-files/openssl.cnf /etc/openssl/openssl.cnf
             export PATH=/sbin:/usr/sbin:$PATH
             ./configure --enable-postgres CPPFLAGS="-I/usr/pkg/include" LDFLAGS="-L/usr/pkg/lib -Wl,-R/usr/pkg/lib"
             make

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ lex.yy.c
 .idea
 unittesting/tmp/
 create_certificate
+wendzelnntpd.conf

--- a/.gitignore
+++ b/.gitignore
@@ -17,4 +17,5 @@ lex.yy.c
 .idea
 unittesting/tmp/
 create_certificate
+docs/create_certificate.8
 wendzelnntpd.conf

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ config.tab.h
 lex.yy.c
 .idea
 unittesting/tmp/
+create_certificate

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -157,6 +157,9 @@ MISC:
    available under https://cdpxe.github.io/WendzelNNTPd/. Generate the PDF
    version of the documentation with pandoc and make it available under
    https://cdpxe.github.io/WendzelNNTPd/docs.pdf.
+ - Move wendzelnntpd.conf into the subdirectory wendzelnntpd together
+   with the SSL certificates, so the new default location for
+   wendzelnntpd.conf is /usr/local/etc/wendzelnntpd/wendzelnntpd.conf.
 
 2.1.3-stable "Friedrichroda" : 17-Apr-2021:
  As usual, every new release gets named after a nice travel location.

--- a/Makefile.in
+++ b/Makefile.in
@@ -62,7 +62,7 @@ DOCFILES_TO_INST=AUTHORS CHANGELOG HISTORY README.md INSTALL LICENSE database/us
 MANPAGES=docs/wendzelnntpd.8 docs/wendzelnntpadm.8
 HTML_DOC_DIRS=$(shell cd docs/ && find site/ -type d)
 
-all : wendzelnntpadm main.o log.o database.o cdpstrings.o server.o lexyacc charstack.o libfunc.o acl.o db_abstraction.o hash.o $(SQLITEOBJ) $(MYSQLOBJ) $(POSTGRESOBJ) $(OPENSSLOBJ) globals.o scripts/startup/init.d_script
+all : wendzelnntpadm main.o log.o database.o cdpstrings.o server.o lexyacc charstack.o libfunc.o acl.o db_abstraction.o hash.o $(SQLITEOBJ) $(MYSQLOBJ) $(POSTGRESOBJ) $(OPENSSLOBJ) globals.o scripts/startup/init.d_script create_certificate
 	expr `cat build` \+ 1 >build
 	$(CC) $(DEBUG) $(CFLAGS) $(LDFLAGS) -o bin/wendzelnntpd main.o log.o server.o lex.yy.o config.tab.o database.o globals.o cdpstrings.o acl.o db_abstraction.o hash.o $(SQLITEOBJ) $(MYSQLOBJ) $(POSTGRESOBJ) charstack.o libfunc.o $(OPENSSLOBJ) $(LIBS)
 	#strip bin/wendzelnntpd
@@ -138,6 +138,10 @@ wendzelnntpadm : cdpnntpadm.o db_abstraction.o $(SQLITEOBJ) $(MYSQLOBJ) $(POSTGR
 
 scripts/startup/init.d_script : Makefile $(srcdir)/scripts/startup/init.d_script_raw
 	sed -e 's|@sbindir[@]|$(sbindir)|g' $@_raw > $@
+
+create_certificate : Makefile $(srcdir)/create_certificate_raw
+	sed -e 's|@sysconfdir[@]|$(sysconfdir)|g' $@_raw > $@
+	chmod +x create_certificate
 
 # misc targets
 

--- a/Makefile.in
+++ b/Makefile.in
@@ -198,6 +198,7 @@ install : bin/wendzelnntpd bin/wendzelnntpadm create_certificate
 
 upgrade : bin/wendzelnntpd bin/wendzelnntpadm
 	@echo "*** Please only upgrade your WendzelNNTPd if your existing installation is WendzelNNTPd version 2.0.0 or newer. This script replaces only binaries and documentation files. Your databases and configuration files remain untouched. Press RETURN to perform an upgrade or press CTRL+C to abort. ***"
+	@if [ ! -f $(DESTDIR)$(confdir)/wendzelnntpd.conf ]; then echo "The format and location of the wendzelnntpd.conf changed in version 2.2.0. Please move your config file from $(DESTDIR)$(sysconfdir)/wendzelnntpd.conf to $(DESTDIR)$(confdir)/wendzelnntpd.conf and adapt the configuration. Please consult the manual in docs/ for further information about the new config format."; fi
 	@read uselessinput
 	# binaries
 	$(INSTALL_PROGRAM) bin/wendzelnntpd bin/wendzelnntpadm $(DESTDIR)$(sbindir)/

--- a/Makefile.in
+++ b/Makefile.in
@@ -38,7 +38,9 @@ SQLITEOBJ=@SQLITEOBJ@
 MYSQLOBJ=@MYSQLOBJ@
 POSTGRESOBJ=@POSTGRESOBJ@
 OPENSSLOBJ=@OPENSSLOBJ@
+
 SQLITEINST=@SQLITEINST@
+TLSINST=@TLSINST@
 
 CONFFILE=wendzelnntpd.conf
 UDBDIR=/var/spool/news/wendzelnntpd
@@ -185,6 +187,10 @@ install : bin/wendzelnntpd bin/wendzelnntpadm
 	@#
 	@# only create if there is no database file already
 	@if [ ! -f $(DESTDIR)$(UDBFILE) ]; then if [ "$(SQLITEINST)" != "NO" ]; then echo "Setting up sqlite3 database ..."; cat database/usenet.db_struct | sqlite3 $(DESTDIR)$(UDBFILE) && ( ./bin/wendzelnntpadm addgroup alt.wendzelnntpd.test y || echo "no new newsgroup created." ); else echo "*** NO sqlite3 database setup performed (you use MySQL). Please read the manual (docs/docs.pdf) to learn how to set up the MySQL database within a few minutes. ***"; fi; fi
+
+	@# create certificates if the certificates do not already exist and TLS support is enabled
+	@if [ ! -f $(DESTDIR)$(confdir)/ssl/server.key ] && [ "$(TLSINST)" != "NO" ]; then ./create_certificate --targetdir $(DESTDIR)$(confdir)/ssl; fi
+
 	@echo "Installation finished. Please note that your existing wendzelnntpd.conf might have been replaced (a backup should be located in the same folder as your original configuration file)."
 	@echo "Thank you for using this software! Have fun using it!"
 

--- a/Makefile.in
+++ b/Makefile.in
@@ -41,6 +41,7 @@ OPENSSLOBJ=@OPENSSLOBJ@
 
 SQLITEINST=@SQLITEINST@
 TLSINST=@TLSINST@
+CREATE_CERTIFICATES=$(TLSINST)
 
 CONFFILE=wendzelnntpd.conf
 UDBDIR=/var/spool/news/wendzelnntpd
@@ -151,7 +152,7 @@ wendzelnntpd.conf : Makefile $(srcdir)/wendzelnntpd.conf_raw
 
 # misc targets
 
-install : bin/wendzelnntpd bin/wendzelnntpadm
+install : bin/wendzelnntpd bin/wendzelnntpadm create_certificate
 	if [ ! -d $(DESTDIR)$(confdir) ]; then $(INSTALL) -d -m 0755 $(DESTDIR)$(confdir); fi
 	if [ ! -d $(DESTDIR)$(sbindir) ]; then $(INSTALL) -d -m 0755 $(DESTDIR)$(sbindir); fi
 	if [ ! -d $(DESTDIR)$(docdir) ]; then $(INSTALL) -d -m 0755 $(DESTDIR)$(docdir); fi
@@ -165,6 +166,7 @@ install : bin/wendzelnntpd bin/wendzelnntpadm
 
 	# binaries
 	$(INSTALL_PROGRAM) bin/wendzelnntpd bin/wendzelnntpadm $(DESTDIR)$(sbindir)/
+	if [ "$(TLSINST)" != "NO" ]; then $(INSTALL_PROGRAM) create_certificate $(DESTDIR)$(sbindir)/; fi
 	# documentation and config files
 	$(INSTALL_DATA) $(DOCFILES_TO_INST) $(DESTDIR)$(docdir)/
 	-$(INSTALL_DATA) docs/docs.pdf $(DESTDIR)$(docdir)/
@@ -188,8 +190,8 @@ install : bin/wendzelnntpd bin/wendzelnntpadm
 	@# only create if there is no database file already
 	@if [ ! -f $(DESTDIR)$(UDBFILE) ]; then if [ "$(SQLITEINST)" != "NO" ]; then echo "Setting up sqlite3 database ..."; cat database/usenet.db_struct | sqlite3 $(DESTDIR)$(UDBFILE) && ( ./bin/wendzelnntpadm addgroup alt.wendzelnntpd.test y || echo "no new newsgroup created." ); else echo "*** NO sqlite3 database setup performed (you use MySQL). Please read the manual (docs/docs.pdf) to learn how to set up the MySQL database within a few minutes. ***"; fi; fi
 
-	@# create certificates if the certificates do not already exist and TLS support is enabled
-	@if [ ! -f $(DESTDIR)$(confdir)/ssl/server.key ] && [ "$(TLSINST)" != "NO" ]; then ./create_certificate --targetdir $(DESTDIR)$(confdir)/ssl; fi
+	@# create certificates if the certificates do not already exist and certificate creation is not disabled
+	@if [ ! -f $(DESTDIR)$(confdir)/ssl/server.key ] && [ "$(CREATE_CERTIFICATES)" != "NO" ]; then ./create_certificate --targetdir $(DESTDIR)$(confdir)/ssl; fi
 
 	@echo "Installation finished. Please note that your existing wendzelnntpd.conf might have been replaced (a backup should be located in the same folder as your original configuration file)."
 	@echo "Thank you for using this software! Have fun using it!"
@@ -199,6 +201,7 @@ upgrade : bin/wendzelnntpd bin/wendzelnntpadm
 	@read uselessinput
 	# binaries
 	$(INSTALL_PROGRAM) bin/wendzelnntpd bin/wendzelnntpadm $(DESTDIR)$(sbindir)/
+	if [ "$(TLSINST)" != "NO" ]; then $(INSTALL_PROGRAM) create_certificate $(DESTDIR)$(sbindir)/; fi
 	# documentation
 	$(INSTALL_DATA) $(DOCFILES_TO_INST) $(DESTDIR)$(docdir)/
 	-$(INSTALL_DATA) docs/docs.pdf $(DESTDIR)$(docdir)/

--- a/Makefile.in
+++ b/Makefile.in
@@ -20,6 +20,7 @@ confdir=$(sysconfdir)/${PACKAGE_TARNAME}
 sbindir=@sbindir@
 datarootdir=@datarootdir@
 datadir=@datadir@
+package_datadir=$(datadir)/${PACKAGE_TARNAME}
 docdir=@docdir@
 mandir=@mandir@
 man8dir=$(mandir)/man8
@@ -144,7 +145,7 @@ scripts/startup/init.d_script : Makefile $(srcdir)/scripts/startup/init.d_script
 	sed -e 's|@sbindir[@]|$(sbindir)|g' $@_raw > $@
 
 create_certificate : Makefile $(srcdir)/create_certificate_raw
-	sed -e 's|@confdir[@]|$(confdir)|g' $@_raw > $@
+	sed -e 's|@confdir[@]|$(confdir)|g' -e 's|@package_datadir[@]|$(package_datadir)|g' $@_raw > $@
 	chmod +x create_certificate
 
 docs/create_certificate.8 : Makefile $(srcdir)/docs/create_certificate.8_raw
@@ -158,6 +159,7 @@ wendzelnntpd.conf : Makefile $(srcdir)/wendzelnntpd.conf_raw
 install : bin/wendzelnntpd bin/wendzelnntpadm create_certificate
 	if [ ! -d $(DESTDIR)$(confdir) ]; then $(INSTALL) -d -m 0755 $(DESTDIR)$(confdir); fi
 	if [ ! -d $(DESTDIR)$(sbindir) ]; then $(INSTALL) -d -m 0755 $(DESTDIR)$(sbindir); fi
+	if [ ! -d $(DESTDIR)$(package_datadir) ]; then $(INSTALL) -d -m 0755 $(DESTDIR)$(package_datadir); fi
 	if [ ! -d $(DESTDIR)$(docdir) ]; then $(INSTALL) -d -m 0755 $(DESTDIR)$(docdir); fi
 	for dir in `cd docs/ && find site/ -type d`; do \
 		if [ ! -d $(DESTDIR)$(docdir)/$$dir ]; then $(INSTALL) -d -m 0755 $(DESTDIR)$(docdir)/$$dir; fi \
@@ -170,6 +172,8 @@ install : bin/wendzelnntpd bin/wendzelnntpadm create_certificate
 	# binaries
 	$(INSTALL_PROGRAM) bin/wendzelnntpd bin/wendzelnntpadm $(DESTDIR)$(sbindir)/
 	if [ "$(TLSINST)" != "NO" ]; then $(INSTALL_PROGRAM) create_certificate $(DESTDIR)$(sbindir)/; fi
+	# data files
+	$(INSTALL_DATA) openssl.cnf $(DESTDIR)$(package_datadir)/
 	# documentation and config files
 	$(INSTALL_DATA) $(DOCFILES_TO_INST) $(DESTDIR)$(docdir)/
 	-$(INSTALL_DATA) docs/docs.pdf $(DESTDIR)$(docdir)/
@@ -194,7 +198,7 @@ install : bin/wendzelnntpd bin/wendzelnntpadm create_certificate
 	@if [ ! -f $(DESTDIR)$(UDBFILE) ]; then if [ "$(SQLITEINST)" != "NO" ]; then echo "Setting up sqlite3 database ..."; cat database/usenet.db_struct | sqlite3 $(DESTDIR)$(UDBFILE) && ( ./bin/wendzelnntpadm addgroup alt.wendzelnntpd.test y || echo "no new newsgroup created." ); else echo "*** NO sqlite3 database setup performed (you use MySQL). Please read the manual (docs/docs.pdf) to learn how to set up the MySQL database within a few minutes. ***"; fi; fi
 
 	@# create certificates if the certificates do not already exist and certificate creation is not disabled
-	@if [ ! -f $(DESTDIR)$(confdir)/ssl/server.key ] && [ "$(CREATE_CERTIFICATES)" != "NO" ]; then bash ./create_certificate --environment local --targetdir $(DESTDIR)$(confdir)/ssl; fi
+	@if [ ! -f $(DESTDIR)$(confdir)/ssl/server.key ] && [ "$(CREATE_CERTIFICATES)" != "NO" ]; then bash create_certificate --environment local --targetdir $(DESTDIR)$(confdir)/ssl; fi
 
 	@echo "Installation finished. Please note that your existing wendzelnntpd.conf might have been replaced (a backup should be located in the same folder as your original configuration file)."
 	@echo "Thank you for using this software! Have fun using it!"
@@ -206,6 +210,8 @@ upgrade : bin/wendzelnntpd bin/wendzelnntpadm
 	# binaries
 	$(INSTALL_PROGRAM) bin/wendzelnntpd bin/wendzelnntpadm $(DESTDIR)$(sbindir)/
 	if [ "$(TLSINST)" != "NO" ]; then $(INSTALL_PROGRAM) create_certificate $(DESTDIR)$(sbindir)/; fi
+	# data files
+	$(INSTALL_DATA) openssl.cnf $(DESTDIR)$(package_datadir)/
 	# documentation
 	$(INSTALL_DATA) $(DOCFILES_TO_INST) $(DESTDIR)$(docdir)/
 	-$(INSTALL_DATA) docs/docs.pdf $(DESTDIR)$(docdir)/

--- a/Makefile.in
+++ b/Makefile.in
@@ -191,7 +191,7 @@ install : bin/wendzelnntpd bin/wendzelnntpadm create_certificate
 	@if [ ! -f $(DESTDIR)$(UDBFILE) ]; then if [ "$(SQLITEINST)" != "NO" ]; then echo "Setting up sqlite3 database ..."; cat database/usenet.db_struct | sqlite3 $(DESTDIR)$(UDBFILE) && ( ./bin/wendzelnntpadm addgroup alt.wendzelnntpd.test y || echo "no new newsgroup created." ); else echo "*** NO sqlite3 database setup performed (you use MySQL). Please read the manual (docs/docs.pdf) to learn how to set up the MySQL database within a few minutes. ***"; fi; fi
 
 	@# create certificates if the certificates do not already exist and certificate creation is not disabled
-	@if [ ! -f $(DESTDIR)$(confdir)/ssl/server.key ] && [ "$(CREATE_CERTIFICATES)" != "NO" ]; then ./create_certificate --targetdir $(DESTDIR)$(confdir)/ssl; fi
+	@if [ ! -f $(DESTDIR)$(confdir)/ssl/server.key ] && [ "$(CREATE_CERTIFICATES)" != "NO" ]; then bash ./create_certificate --environment local --targetdir $(DESTDIR)$(confdir)/ssl; fi
 
 	@echo "Installation finished. Please note that your existing wendzelnntpd.conf might have been replaced (a backup should be located in the same folder as your original configuration file)."
 	@echo "Thank you for using this software! Have fun using it!"

--- a/Makefile.in
+++ b/Makefile.in
@@ -16,6 +16,7 @@ SRC=$(srcdir)/src
 prefix=@prefix@
 exec_prefix=@exec_prefix@
 sysconfdir=@sysconfdir@
+confdir=$(sysconfdir)/${PACKAGE_TARNAME}
 sbindir=@sbindir@
 datarootdir=@datarootdir@
 datadir=@datadir@
@@ -42,7 +43,7 @@ SQLITEINST=@SQLITEINST@
 CONFFILE=wendzelnntpd.conf
 UDBDIR=/var/spool/news/wendzelnntpd
 UDBFILE=$(UDBDIR)/usenet.db
-DESTCFLAGS=-DCONFDIR=\"$(sysconfdir)\"
+DESTCFLAGS=-DCONFDIR=\"$(confdir)\"
 HEADERS=$(SRC)/include/cdpstrings.h $(SRC)/include/main.h $(SRC)/include/wendzelnntpdpath.h
 CFLAGS+= -Wall $(DESTCFLAGS)
 #CFLAGS+=-Wmissing-prototypes -Wmissing-declarations -Wshadow -Wcast-qual \
@@ -62,7 +63,7 @@ DOCFILES_TO_INST=AUTHORS CHANGELOG HISTORY README.md INSTALL LICENSE database/us
 MANPAGES=docs/wendzelnntpd.8 docs/wendzelnntpadm.8
 HTML_DOC_DIRS=$(shell cd docs/ && find site/ -type d)
 
-all : wendzelnntpadm main.o log.o database.o cdpstrings.o server.o lexyacc charstack.o libfunc.o acl.o db_abstraction.o hash.o $(SQLITEOBJ) $(MYSQLOBJ) $(POSTGRESOBJ) $(OPENSSLOBJ) globals.o scripts/startup/init.d_script create_certificate
+all : wendzelnntpadm main.o log.o database.o cdpstrings.o server.o lexyacc charstack.o libfunc.o acl.o db_abstraction.o hash.o $(SQLITEOBJ) $(MYSQLOBJ) $(POSTGRESOBJ) $(OPENSSLOBJ) globals.o scripts/startup/init.d_script create_certificate wendzelnntpd.conf
 	expr `cat build` \+ 1 >build
 	$(CC) $(DEBUG) $(CFLAGS) $(LDFLAGS) -o bin/wendzelnntpd main.o log.o server.o lex.yy.o config.tab.o database.o globals.o cdpstrings.o acl.o db_abstraction.o hash.o $(SQLITEOBJ) $(MYSQLOBJ) $(POSTGRESOBJ) charstack.o libfunc.o $(OPENSSLOBJ) $(LIBS)
 	#strip bin/wendzelnntpd
@@ -140,13 +141,16 @@ scripts/startup/init.d_script : Makefile $(srcdir)/scripts/startup/init.d_script
 	sed -e 's|@sbindir[@]|$(sbindir)|g' $@_raw > $@
 
 create_certificate : Makefile $(srcdir)/create_certificate_raw
-	sed -e 's|@sysconfdir[@]|$(sysconfdir)|g' $@_raw > $@
+	sed -e 's|@confdir[@]|$(confdir)|g' $@_raw > $@
 	chmod +x create_certificate
+
+wendzelnntpd.conf : Makefile $(srcdir)/wendzelnntpd.conf_raw
+	sed -e 's|@confdir[@]|$(confdir)|g' $@_raw > $@
 
 # misc targets
 
 install : bin/wendzelnntpd bin/wendzelnntpadm
-	if [ ! -d $(DESTDIR)$(sysconfdir) ]; then $(INSTALL) -d -m 0755 $(DESTDIR)$(sysconfdir); fi
+	if [ ! -d $(DESTDIR)$(confdir) ]; then $(INSTALL) -d -m 0755 $(DESTDIR)$(confdir); fi
 	if [ ! -d $(DESTDIR)$(sbindir) ]; then $(INSTALL) -d -m 0755 $(DESTDIR)$(sbindir); fi
 	if [ ! -d $(DESTDIR)$(docdir) ]; then $(INSTALL) -d -m 0755 $(DESTDIR)$(docdir); fi
 	for dir in `cd docs/ && find site/ -type d`; do \
@@ -168,8 +172,8 @@ install : bin/wendzelnntpd bin/wendzelnntpadm
 	# manpages
 	$(INSTALL_DATA) $(MANPAGES) $(DESTDIR)$(man8dir)
 	# config
-	@if [ -f $(DESTDIR)$(sysconfdir)/wendzelnntpd.conf ]; then cp $(DESTDIR)$(sysconfdir)/wendzelnntpd.conf $(DESTDIR)$(sysconfdir)/wendzelnntpd.conf.bkp; chmod 0644 $(DESTDIR)$(sysconfdir)/wendzelnntpd.conf.bkp; echo "***Your old wendzelnntpd.conf was backuped!***"; fi
-	$(INSTALL_DATA) $(CONFFILE) $(DESTDIR)$(sysconfdir)/wendzelnntpd.conf
+	@if [ -f $(DESTDIR)$(confdir)/wendzelnntpd.conf ]; then cp $(DESTDIR)$(confdir)/wendzelnntpd.conf $(DESTDIR)$(confdir)/wendzelnntpd.conf.bkp; chmod 0644 $(DESTDIR)$(confdir)/wendzelnntpd.conf.bkp; echo "***Your old wendzelnntpd.conf was backuped!***"; fi
+	$(INSTALL_DATA) $(CONFFILE) $(DESTDIR)$(confdir)/wendzelnntpd.conf
 	# create a backup of the old usenet database, if needed (only if not dev-mode)
 	@if [ -f $(DESTDIR)$(UDBFILE) ] && [ $(CONFFILE) != *"dev"* ]; then mv $(DESTDIR)$(UDBFILE) $(DESTDIR)$(UDBFILE).`date +"%m-%d-%y-%H:%M"`.bkp; chmod 0600 $(DESTDIR)$(UDBFILE).`date +"%m-%d-%y-%H:%M"`.bkp; echo "***Your old usenet database was backuped!***"; fi
 

--- a/Makefile.in
+++ b/Makefile.in
@@ -63,10 +63,10 @@ DEBUG=$(GDBON) -DDEBUG -DXXDEBUG
 
 # The list of documentation files we wish to install
 DOCFILES_TO_INST=AUTHORS CHANGELOG HISTORY README.md INSTALL LICENSE database/usenet.db_struct database/mysql_db_struct.sql
-MANPAGES=docs/wendzelnntpd.8 docs/wendzelnntpadm.8
+MANPAGES=docs/wendzelnntpd.8 docs/wendzelnntpadm.8 docs/create_certificate.8
 HTML_DOC_DIRS=$(shell cd docs/ && find site/ -type d)
 
-all : wendzelnntpadm main.o log.o database.o cdpstrings.o server.o lexyacc charstack.o libfunc.o acl.o db_abstraction.o hash.o $(SQLITEOBJ) $(MYSQLOBJ) $(POSTGRESOBJ) $(OPENSSLOBJ) globals.o scripts/startup/init.d_script create_certificate wendzelnntpd.conf
+all : wendzelnntpadm main.o log.o database.o cdpstrings.o server.o lexyacc charstack.o libfunc.o acl.o db_abstraction.o hash.o $(SQLITEOBJ) $(MYSQLOBJ) $(POSTGRESOBJ) $(OPENSSLOBJ) globals.o scripts/startup/init.d_script create_certificate docs/create_certificate.8 wendzelnntpd.conf
 	expr `cat build` \+ 1 >build
 	$(CC) $(DEBUG) $(CFLAGS) $(LDFLAGS) -o bin/wendzelnntpd main.o log.o server.o lex.yy.o config.tab.o database.o globals.o cdpstrings.o acl.o db_abstraction.o hash.o $(SQLITEOBJ) $(MYSQLOBJ) $(POSTGRESOBJ) charstack.o libfunc.o $(OPENSSLOBJ) $(LIBS)
 	#strip bin/wendzelnntpd
@@ -146,6 +146,9 @@ scripts/startup/init.d_script : Makefile $(srcdir)/scripts/startup/init.d_script
 create_certificate : Makefile $(srcdir)/create_certificate_raw
 	sed -e 's|@confdir[@]|$(confdir)|g' $@_raw > $@
 	chmod +x create_certificate
+
+docs/create_certificate.8 : Makefile $(srcdir)/docs/create_certificate.8_raw
+	sed -e 's|@confdir[@]|$(confdir)|g' $@_raw > $@
 
 wendzelnntpd.conf : Makefile $(srcdir)/wendzelnntpd.conf_raw
 	sed -e 's|@confdir[@]|$(confdir)|g' $@_raw > $@

--- a/configure
+++ b/configure
@@ -677,6 +677,7 @@ LEX
 INSTALL_DATA
 INSTALL_SCRIPT
 INSTALL_PROGRAM
+TLSINST
 OPENSSLOBJ
 OPENSSL
 OPENSSL_LDFLAGS
@@ -2610,6 +2611,7 @@ then :
 fi
 
 
+# Check if at least one of the databases is enabled
 if test "x$enable_mysql" = "xno" && test "x$enable_sqlite" = "xno" && test "x$enable_postgres" != "xyes"
 then :
 
@@ -5196,6 +5198,11 @@ then :
 
 fi
 	OPENSSLOBJ=libssl.o
+
+
+else $as_nop
+
+	TLSINST=NO
 
 
 fi

--- a/configure.ac
+++ b/configure.ac
@@ -75,6 +75,8 @@ AS_IF([test "x$enable_tls" != "xno"], [
 		AC_MSG_ERROR([You need openssl in your PATH])
 	])
 	AC_SUBST([OPENSSLOBJ], [libssl.o])
+], [
+	AC_SUBST([TLSINST], [NO])
 ])
 
 # Checks for programs.

--- a/create_certificate
+++ b/create_certificate
@@ -49,7 +49,7 @@ if [[ -z $environment || "$environment" = "local" ]]; then
         -days 3650 \
         -nodes \
         -extensions v3_ca \
-        -subj "/C=DE/ST=Hagen/O=Test-Cert Inc." \
+        -config "openssl.cnf" \
         -keyout "/usr/local/etc/ssl/ca-key.pem" \
         -out "/usr/local/etc/ssl/ca.crt"
 
@@ -57,7 +57,7 @@ if [[ -z $environment || "$environment" = "local" ]]; then
     openssl req \
         -new -key "/usr/local/etc/ssl/server.key" \
         -out "/usr/local/etc/ssl/server.csr" \
-        -config "./docker/openssl/openssl.cnf"
+        -config "openssl.cnf"
 
     openssl x509 \
         -req \
@@ -67,7 +67,7 @@ if [[ -z $environment || "$environment" = "local" ]]; then
         -CAkey "/usr/local/etc/ssl/ca-key.pem" \
         -CAcreateserial \
         -extensions v3_req \
-        -extfile "./docker/openssl/openssl.cnf" \
+        -extfile "openssl.cnf" \
         -out "/usr/local/etc/ssl/server.crt"
 
     echo "Finished ..."

--- a/create_certificate_raw
+++ b/create_certificate_raw
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 
 echo "This is the WendzelNNTPd script for generating SSL certificates."
 echo

--- a/create_certificate_raw
+++ b/create_certificate_raw
@@ -3,7 +3,7 @@
 echo "This is the WendzelNNTPd script for generating SSL certificates."
 echo
 
-targetdir=@sysconfdir@/ssl
+targetdir=@confdir@/ssl
 
 function usage {
     echo ""
@@ -17,7 +17,7 @@ function usage {
     echo "  --domain string         only needed if 'letsencrypt' is used; specify domain under which your server is reachable"
     echo "                          (example: test.de)"
     echo "  --targetdir string      specify the directory where the created certificates are placed into"
-    echo "                          (default: @sysconfdir@/ssl)"
+    echo "                          (default: @confdir@/ssl)"
     echo ""
 }
 

--- a/create_certificate_raw
+++ b/create_certificate_raw
@@ -37,7 +37,7 @@ done
 
 if [ $(id -u) -ne 0 ]; then
     echo "Run this script with root privileges!"
-    exit
+    exit 1
 fi
 
 mkdir -p ${targetdir}

--- a/create_certificate_raw
+++ b/create_certificate_raw
@@ -3,6 +3,8 @@
 echo "This is the WendzelNNTPd script for generating SSL certificates."
 echo
 
+targetdir=@sysconfdir@/ssl
+
 function usage {
     echo ""
     echo "Creates certificates for WendzelNNTPd (selfsigned or via LetsEncrypt)"
@@ -14,6 +16,8 @@ function usage {
     echo "                          (example: test@test.de)"
     echo "  --domain string         only needed if 'letsencrypt' is used; specify domain under which your server is reachable"
     echo "                          (example: test.de)"
+    echo "  --targetdir string      specify the directory where the created certificates are placed into"
+    echo "                          (default: @sysconfdir@/ssl)"
     echo ""
 }
 
@@ -36,7 +40,7 @@ if [ $(id -u) -ne 0 ]; then
     exit
 fi
 
-mkdir -p /usr/local/etc/ssl
+mkdir -p ${targetdir}
 
 if [[ -z $environment || "$environment" = "local" ]]; then
     echo "Environment is set to 'local'. Certificates for 'local' use are generated now..."
@@ -50,28 +54,28 @@ if [[ -z $environment || "$environment" = "local" ]]; then
         -nodes \
         -extensions v3_ca \
         -config "openssl.cnf" \
-        -keyout "/usr/local/etc/ssl/ca-key.pem" \
-        -out "/usr/local/etc/ssl/ca.crt"
+        -keyout "${targetdir}/ca-key.pem" \
+        -out "${targetdir}/ca.crt"
 
-    openssl genrsa -out "/usr/local/etc/ssl/server.key" 2048
+    openssl genrsa -out "${targetdir}/server.key" 2048
     openssl req \
-        -new -key "/usr/local/etc/ssl/server.key" \
-        -out "/usr/local/etc/ssl/server.csr" \
+        -new -key "${targetdir}/server.key" \
+        -out "${targetdir}/server.csr" \
         -config "openssl.cnf"
 
     openssl x509 \
         -req \
         -days 365 \
-        -in "/usr/local/etc/ssl/server.csr" \
-        -CA "/usr/local/etc/ssl/ca.crt" \
-        -CAkey "/usr/local/etc/ssl/ca-key.pem" \
+        -in "${targetdir}/server.csr" \
+        -CA "${targetdir}/ca.crt" \
+        -CAkey "${targetdir}/ca-key.pem" \
         -CAcreateserial \
         -extensions v3_req \
         -extfile "openssl.cnf" \
-        -out "/usr/local/etc/ssl/server.crt"
+        -out "${targetdir}/server.crt"
 
     echo "Finished ..."
-    echo "You can find the certificate at: /usr/local/etc/ssl/server.crt, key: /usr/local/etc/ssl/server.key, CA certificate: /usr/local/etc/ssl/ca.crt"
+    echo "You can find the certificate at: ${targetdir}/server.crt, key: ${targetdir}/server.key, CA certificate: ${targetdir}/ca.crt"
     echo
 elif [ "$environment" = "letsencrypt" ]; then
     echo "Environment is set to local. Certificates are generated now via LetsEncrypt certbot..."
@@ -91,12 +95,12 @@ elif [ "$environment" = "letsencrypt" ]; then
     echo "Generating certificates..."
     certbot certonly --standalone -n --agree-tos --email $email --domains $domain --cert-name wendzelnntpd
 
-    ln -sf /etc/letsencrypt/live/wendzelnntpd/fullchain.pem /usr/local/etc/ssl/server.crt
-    ln -sf /etc/letsencrypt/live/wendzelnntpd/privkey.pem /usr/local/etc/ssl/server.key
-    ln -sf /etc/letsencrypt/live/wendzelnntpd/chain.pem /usr/local/etc/ssl/ca.crt
+    ln -sf /etc/letsencrypt/live/wendzelnntpd/fullchain.pem ${targetdir}/server.crt
+    ln -sf /etc/letsencrypt/live/wendzelnntpd/privkey.pem ${targetdir}/server.key
+    ln -sf /etc/letsencrypt/live/wendzelnntpd/chain.pem ${targetdir}/ca.crt
 
     echo "Finished ..."
-    echo "You can find certificate at: /usr/local/etc/ssl/server.crt, key: /usr/local/etc/ssl/server.key, CA certificate: /usr/local/etc/ssl/ca.crt"
+    echo "You can find certificate at: ${targetdir}/server.crt, key: ${targetdir}/server.key, CA certificate: ${targetdir}/ca.crt"
     echo
 else
     echo "Unknown environment for script generation provided..."

--- a/create_certificate_raw
+++ b/create_certificate_raw
@@ -5,6 +5,7 @@ echo "This is the WendzelNNTPd script for generating SSL certificates."
 echo
 
 targetdir=@confdir@/ssl
+datadir=@package_datadir@
 
 function usage {
     echo ""
@@ -54,7 +55,7 @@ if [[ -z $environment || "$environment" = "local" ]]; then
         -days 3650 \
         -nodes \
         -extensions v3_ca \
-        -config "openssl.cnf" \
+        -config "${datadir}/openssl.cnf" \
         -keyout "${targetdir}/ca-key.pem" \
         -out "${targetdir}/ca.crt"
 
@@ -62,7 +63,7 @@ if [[ -z $environment || "$environment" = "local" ]]; then
     openssl req \
         -new -key "${targetdir}/server.key" \
         -out "${targetdir}/server.csr" \
-        -config "openssl.cnf"
+        -config "${datadir}/openssl.cnf"
 
     openssl x509 \
         -req \
@@ -72,7 +73,7 @@ if [[ -z $environment || "$environment" = "local" ]]; then
         -CAkey "${targetdir}/ca-key.pem" \
         -CAcreateserial \
         -extensions v3_req \
-        -extfile "openssl.cnf" \
+        -extfile "${datadir}/openssl.cnf" \
         -out "${targetdir}/server.crt"
 
     echo "Finished ..."

--- a/create_certificate_raw
+++ b/create_certificate_raw
@@ -9,7 +9,7 @@ function usage {
     echo ""
     echo "Creates certificates for WendzelNNTPd (selfsigned or via LetsEncrypt)"
     echo ""
-    echo "usage: ./create_certificate --environment local | letsencrypt --email string --domain string"
+    echo "usage: create_certificate --environment local | letsencrypt --email string --domain string"
     echo ""
     echo "  --environment string    context for generating certificates ('local' and 'letsencrypt' are allowed values)"
     echo "  --email string          only needed if 'letsencrypt' is used"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -8,7 +8,7 @@ RUN go install github.com/cespare/reflex@latest
 
 RUN touch /var/log/wendzelnntpd
 
-COPY docker/openssl/openssl.cnf /usr/local/etc/ssl/openssl.cnf
+COPY openssl.cnf /usr/local/etc/ssl/openssl.cnf
 
 # Create server certificate for TLS
 RUN mkdir -p /usr/local/etc/ssl
@@ -20,7 +20,7 @@ RUN openssl req \
   -days 3650 \
   -nodes \
   -extensions v3_ca \
-  -subj "/C=DE/ST=Hagen/O=Test-Cert Inc." \
+  -config "/usr/local/etc/ssl/openssl.cnf" \
   -keyout "/usr/local/etc/ssl/ca-key.pem" \
   -out "/usr/local/etc/ssl/ca.crt"
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,17 +1,17 @@
 FROM debian:stable-slim
 
-RUN apt-get update -y
-RUN apt-get install -y gcc flex bison sqlite3 libsqlite3-dev mariadb-client libmariadb-dev-compat ca-certificates libmariadb-dev libmhash-dev make golang-go openssl libssl-dev gdb
+RUN apt-get update -y && apt-get install -y gcc flex bison sqlite3 libsqlite3-dev mariadb-client libmariadb-dev-compat \
+    ca-certificates libmariadb-dev libmhash-dev make golang-go openssl libssl-dev gdb
 
 # install reflex for on-demand compiling of source code
 RUN go install github.com/cespare/reflex@latest
 
 RUN touch /var/log/wendzelnntpd
 
-COPY openssl.cnf /usr/local/etc/ssl/openssl.cnf
+COPY openssl.cnf /usr/local/etc/wendzelnntpd/ssl/openssl.cnf
 
 # Create server certificate for TLS
-RUN mkdir -p /usr/local/etc/ssl
+RUN mkdir -p /usr/local/etc/wendzelnntpd/ssl
 # create CA
 RUN openssl req \
   -x509 \
@@ -20,29 +20,31 @@ RUN openssl req \
   -days 3650 \
   -nodes \
   -extensions v3_ca \
-  -config "/usr/local/etc/ssl/openssl.cnf" \
-  -keyout "/usr/local/etc/ssl/ca-key.pem" \
-  -out "/usr/local/etc/ssl/ca.crt"
+  -config "/usr/local/etc/wendzelnntpd/ssl/openssl.cnf" \
+  -keyout "/usr/local/etc/wendzelnntpd/ssl/ca-key.pem" \
+  -out "/usr/local/etc/wendzelnntpd/ssl/ca.crt"
 
-RUN openssl genrsa -out "/usr/local/etc/ssl/server.key" 2048
+RUN openssl genrsa -out "/usr/local/etc/wendzelnntpd/ssl/server.key" 2048
 RUN openssl req \
-  -new -key "/usr/local/etc/ssl/server.key" \
-  -out "/usr/local/etc/ssl/server.csr" \
-  -config "/usr/local/etc/ssl/openssl.cnf"
+  -new -key "/usr/local/etc/wendzelnntpd/ssl/server.key" \
+  -out "/usr/local/etc/wendzelnntpd/ssl/server.csr" \
+  -config "/usr/local/etc/wendzelnntpd/ssl/openssl.cnf"
 
 RUN openssl x509 \
     -req \
     -days 365 \
-    -in "/usr/local/etc/ssl/server.csr" \
-    -CA "/usr/local/etc/ssl/ca.crt" \
-    -CAkey "/usr/local/etc/ssl/ca-key.pem" \
+    -in "/usr/local/etc/wendzelnntpd/ssl/server.csr" \
+    -CA "/usr/local/etc/wendzelnntpd/ssl/ca.crt" \
+    -CAkey "/usr/local/etc/wendzelnntpd/ssl/ca-key.pem" \
     -CAcreateserial \
     -extensions v3_req \
-    -extfile "/usr/local/etc/ssl/openssl.cnf" \
-    -out "/usr/local/etc/ssl/server.crt"
+    -extfile "/usr/local/etc/wendzelnntpd/ssl/openssl.cnf" \
+    -out "/usr/local/etc/wendzelnntpd/ssl/server.crt"
 
 # for local development only copy existing certificate (GitHub Action will use different certificates there)
-RUN cp /usr/local/etc/ssl/server.crt /usr/local/etc/ssl/server-self.crt && cp /usr/local/etc/ssl/server.key /usr/local/etc/ssl/server-self.key && cp /usr/local/etc/ssl/ca.crt /usr/local/etc/ssl/ca-self.crt
+RUN cp /usr/local/etc/wendzelnntpd/ssl/server.crt /usr/local/etc/wendzelnntpd/ssl/server-self.crt \
+    && cp /usr/local/etc/wendzelnntpd/ssl/server.key /usr/local/etc/wendzelnntpd/ssl/server-self.key \
+    && cp /usr/local/etc/wendzelnntpd/ssl/ca.crt /usr/local/etc/wendzelnntpd/ssl/ca-self.crt
 
 WORKDIR /wendzelnntpd
 

--- a/docs/create_certificate.8_raw
+++ b/docs/create_certificate.8_raw
@@ -1,0 +1,45 @@
+.TH CREATE_CERTIFICATE 8 "21 Sep 2025" ""
+.\"=====================================================================
+.SH "NAME"
+create_certificate \- Creates certificates for \fBwendzelnntpd(8)\fP (selfsigned or via LetsEncrypt).
+
+.SH "SYNOPSIS"
+\fBcreate_certificate\fP [options]
+
+.SH "DESCRIPTION"
+.B create_certificate
+is used to create certificates for \fBwendzelnntpd(8)\fP (selfsigned or via LetsEncrypt) for SSL connections.
+
+.\"=====================================================================
+.SH OPTIONS
+This version of \fBcreate_certificate\fP understands the following options.
+.TP
+\fB\-\-environment\fR
+context for generating certificates ('local' and 'letsencrypt' are allowed values)
+.TP
+\fB\-\-email\fR
+only needed if 'letsencrypt' is used (example: test@test.de)
+.TP
+\fB\-\-domain\fR
+Only needed if 'letsencrypt' is used; specify domain under which your server is reachable (example: test.de)
+.TP
+\fB\-\-targetdir\fR
+specify the directory where the created certificates are placed into (default: @confdir@/ssl)
+
+.SH "WEBSITE"
+\fIhttps://www.wendzel.de\fP
+and
+\fIhttps://cdpxe.github.io/WendzelNNTPd/\fP
+
+.SH "AUTHORS"
+WendzelNNTPd was originally developed by Steffen Wendzel. The development started in 2004. See the
+.I
+AUTHORS
+file for a list of all major contributors.
+
+.SH "BUGS"
+Please send bug reports to  \fIsteffen@wendzel.de\fP.
+
+.SH SEE ALSO
+.BR wendzelnntpd (8)
+.BR wendzelnntpadm (8)

--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -4,13 +4,13 @@ This chapter will explain how to configure WendzelNNTPd after
 installation.
 
 **Note:** The configuration file for WendzelNNTPd is named
-*/usr/local/etc/wendzelnntpd.conf*. The format of the configuration file
+*/usr/local/etc/wendzelnntpd/wendzelnntpd.conf*. The format of the configuration file
 should be self-explanatory and the default configuration file includes
 many comments which will help you to understand its content.
 
 **Note:** On \*nix-like operating systems the default installation path
 is */usr/local/\**, i.e., the configuration file of WendzelNNTPd will be
-*/usr/local/etc/wendzelnntpd.conf*, and the binaries will be placed in
+*/usr/local/etc/wendzelnntpd/wendzelnntpd.conf*, and the binaries will be placed in
 */usr/local/sbin*.
 
 ## Choosing a database engine
@@ -107,11 +107,11 @@ connector. You can find an example for NNTP over port 119 below.
     port        119
     listen      127.0.0.1
     ;; configure SSL server certificate (required)
-    ;tls-server-certificate "/usr/local/etc/ssl/server.crt"
+    ;tls-server-certificate "/usr/local/etc/wendzelnntpd/ssl/server.crt"
     ;; configure SSL private key (required)
-    ;tls-server-key "/usr/local/etc/ssl/server.key"
+    ;tls-server-key "/usr/local/etc/wendzelnntpd/ssl/server.key"
     ;; configure SSL CA certificate (required)
-    ;tls-ca-certificate "/usr/local/etc/ssl/ca.crt"
+    ;tls-ca-certificate "/usr/local/etc/wendzelnntpd/ssl/ca.crt"
     ;; configure TLS ciphers for TLSv1.3
     ;tls-cipher-suites "TLS_AES_128_GCM_SHA256"
     ;; configure TLS ciphers for TLSv1.1 and TLSv1.2
@@ -125,7 +125,7 @@ connector. You can find an example for NNTP over port 119 below.
     ;tls-verify-client-depth 0
     ;; possibility to use certificate revocation list (none | leaf | chain)
     ;tls-crl "none"
-    ;tls-crl-file "/usr/local/etc/ssl/ssl.crl"
+    ;tls-crl-file "/usr/local/etc/wendzelnntpd/ssl/ssl.crl"
 </connector>
 ```
 
@@ -138,11 +138,11 @@ The example below is for SNNTP over port 563.
     port        563
     listen      127.0.0.1
     ;; configure SSL server certificate (required)
-    ;tls-server-certificate "/usr/local/etc/ssl/server.crt"
+    ;tls-server-certificate "/usr/local/etc/wendzelnntpd/ssl/server.crt"
     ;; configure SSL private key (required)
-    ;tls-server-key "/usr/local/etc/ssl/server.key"
+    ;tls-server-key "/usr/local/etc/wendzelnntpd/ssl/server.key"
     ;; configure SSL CA certificate (required)
-    ;tls-ca-certificate "/usr/local/etc/ssl/ca.crt"
+    ;tls-ca-certificate "/usr/local/etc/wendzelnntpd/ssl/ca.crt"
     ;; configure TLS ciphers for TLSv1.3
     ;tls-cipher-suites "TLS_AES_128_GCM_SHA256"
     ;; configure TLS ciphers for TLSv1.1 and TLSv1.2
@@ -156,7 +156,7 @@ The example below is for SNNTP over port 563.
     ;tls-verify-client-depth 0
     ;; possibility to use certificate revocation list (none | leaf | chain)
     ;tls-crl "none"
-    ;tls-crl-file "/usr/local/etc/ssl/ssl.crl"
+    ;tls-crl-file "/usr/local/etc/wendzelnntpd/ssl/ssl.crl"
 </connector>
 ```
 

--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -98,72 +98,143 @@ wendzelnntpd=> commit; quit;
 
 ## Network Settings
 
-For each type of IP address (IPv4 and/or IPv6) you have to define a own
-connector. You can find an example for NNTP over port 119 below.
+For each type of IP address (IPv4 and/or IPv6) you have to define an own
+connector. You can find a minimal example for NNTP over port 119 on
+localhost over IPv4 and IPv6 below.
 ```ini
 <connector>
-    ;; enables STARTTLS for this port
-    ;enable-starttls
-    port        119
-    listen      127.0.0.1
-    ;; configure SSL server certificate (required)
-    ;tls-server-certificate "/usr/local/etc/wendzelnntpd/ssl/server.crt"
-    ;; configure SSL private key (required)
-    ;tls-server-key "/usr/local/etc/wendzelnntpd/ssl/server.key"
-    ;; configure SSL CA certificate (required)
-    ;tls-ca-certificate "/usr/local/etc/wendzelnntpd/ssl/ca.crt"
-    ;; configure TLS ciphers for TLSv1.3
-    ;tls-cipher-suites "TLS_AES_128_GCM_SHA256"
-    ;; configure TLS ciphers for TLSv1.1 and TLSv1.2
-    ;tls-ciphers "ALL:!COMPLEMENTOFDEFAULT:!eNULL"
-    ;; configure allowed TLS version (1.0-1.3)
-    ;tls-version "1.2-1.3"
-    ;; possibility to force the client to authenticate 
-    ;;with client certificate (none | optional | require)
-    ;tls-verify-client "required"
-    ;; define depth for checking client certificate
-    ;tls-verify-client-depth 0
-    ;; possibility to use certificate revocation list (none | leaf | chain)
-    ;tls-crl "none"
-    ;tls-crl-file "/usr/local/etc/wendzelnntpd/ssl/ssl.crl"
+    port		119
+    listen	    127.0.0.1
+</connector>
+
+<connector>
+    port		119
+    listen	    ::1
 </connector>
 ```
 
+### Encrypted connections over TLS
+
+WendzelNNTPd supports encrypted connections over TLS. There are two
+ways to use TLS: STARTTLS and dedicated TLS (SNNTP).
+Both ways require an SSL certificate, which is created during installation
+by default, but you can also create a new certificate or provide your own
+(see [Generating SSL certificates](install.md#generating-ssl-certificates)
+for more information).
+The configuration options `tls-server-certificate`, `tls-server-key` and
+`tls-ca-certificate` contain the paths to the SSL certificate, the private
+key of the certificate and the certificate of the certificate authority (CA)
+which signed the SSL certificate.
+These options are required for using TLS or STARTTLS with NNTP.
+All other TLS-related options are optional.
+
+#### STARTTLS
+
+STARTTLS can be added to an existing port and makes it possible
+to create encrypted and unencrypted connections over the same port.
+Encrypted connections are created by starting an unencrypted connection
+and switching to TLS using the STARTTLS NNTP command.
+The example below is for NNTP over port 119.
+```ini
+<connector>
+    ;; enables STARTTLS for this port
+    enable-starttls
+    port        119
+    listen	    127.0.0.1
+    ;; configure SSL server certificate (required)
+    tls-server-certificate "/usr/local/etc/wendzelnntpd/ssl/server.crt"
+    ;; configure SSL private key (required)
+    tls-server-key "/usr/local/etc/wendzelnntpd/ssl/server.key"
+    ;; configure SSL CA certificate (required)
+    tls-ca-certificate "/usr/local/etc/wendzelnntpd/ssl/ca.crt"
+    ;; configure TLS ciphers for TLSv1.3
+    tls-cipher-suites "TLS_AES_128_GCM_SHA256"
+    ;; configure TLS ciphers for TLSv1.1 and TLSv1.2
+    tls-ciphers "ALL:!COMPLEMENTOFDEFAULT:!eNULL"
+    ;; configure allowed TLS version (1.0-1.3)
+    tls-version "1.2-1.3"
+</connector>
+```
+
+#### Dedicated TLS (SNNTP)
+
 To use dedicated TLS with NNTP (SNNTP) you can define another connector.
+This connector only accepts encrypted connections.
 The example below is for SNNTP over port 563.
 ```ini
 <connector>
     ;; enables TLS for this port
-    ;enable-tls
+    enable-tls
     port        563
-    listen      127.0.0.1
+    listen	    127.0.0.1
     ;; configure SSL server certificate (required)
-    ;tls-server-certificate "/usr/local/etc/wendzelnntpd/ssl/server.crt"
+    tls-server-certificate "/usr/local/etc/wendzelnntpd/ssl/server.crt"
     ;; configure SSL private key (required)
-    ;tls-server-key "/usr/local/etc/wendzelnntpd/ssl/server.key"
+    tls-server-key "/usr/local/etc/wendzelnntpd/ssl/server.key"
     ;; configure SSL CA certificate (required)
-    ;tls-ca-certificate "/usr/local/etc/wendzelnntpd/ssl/ca.crt"
+    tls-ca-certificate "/usr/local/etc/wendzelnntpd/ssl/ca.crt"
     ;; configure TLS ciphers for TLSv1.3
-    ;tls-cipher-suites "TLS_AES_128_GCM_SHA256"
+    tls-cipher-suites "TLS_AES_128_GCM_SHA256"
     ;; configure TLS ciphers for TLSv1.1 and TLSv1.2
-    ;tls-ciphers "ALL:!COMPLEMENTOFDEFAULT:!eNULL"
+    tls-ciphers "ALL:!COMPLEMENTOFDEFAULT:!eNULL"
     ;; configure allowed TLS version (1.0-1.3)
-    ;tls-version "1.2-1.3"
-    ;; possibility to force the client to authenticate 
-    ;;with client certificate (none | optional | require)
-    ;tls-verify-client "required"
-    ;; define depth for checking client certificate
-    ;tls-verify-client-depth 0
-    ;; possibility to use certificate revocation list (none | leaf | chain)
-    ;tls-crl "none"
-    ;tls-crl-file "/usr/local/etc/wendzelnntpd/ssl/ssl.crl"
+    tls-version "1.2-1.3"
 </connector>
 ```
 
-The configuration options *tls-server-certificate*, *tls-server-key* and
-*tls-ca-certificate* are required for using TLS or STARTTLS with NNTP.
-All other TLS-related options are optional. More examples are in the
-existing *wendzelnntpd.conf* file.
+#### Mutual authentication (mTLS) and certificate revocation lists (CRLs)
+
+WendzelNNTPd supports mutual authentication over TLS (mTLS).
+The option `tls-verify-client` enables mTLS, which accepts the following options:
+
+- require: the client certificate is requested and validated by the server
+- optional: the client certificate is not requested by the server, but validated if sent by the client
+- none: the client certificate is neither requested nor validated by the server
+
+The option `tls-verify-client-depth` defines the depth of the validation of the certificate chain.
+It needs to be set to 0 if selfsigned certificates are used.
+
+It is possible to check the client certificates against a certificate revocation list (CRL).
+The option `tls-crl` enables CRL checking, which accepts the following options:
+
+- chain: the entire certificate chain of the client certificate is checked against the CRL
+- leaf: the client certificate is checked against the CRL
+- none: CRL checking is disabled
+
+```ini
+; mutual auth needed
+<connector>
+    enable-tls
+    port        563
+    listen	    127.0.0.1
+
+    tls-server-certificate "/usr/local/etc/wendzelnntpd/ssl/server.crt"
+    tls-server-key "/usr/local/etc/wendzelnntpd/ssl/server.key"
+    tls-ca-certificate "/usr/local/etc/wendzelnntpd/ssl/ca.crt"
+    tls-cipher-suites "TLS_AES_128_GCM_SHA256"
+    tls-ciphers "ALL:!COMPLEMENTOFDEFAULT:!eNULL"
+    tls-version "1.3-1.3"
+
+    ; possibility to force the client to authenticate with
+    ; client certificate (none | optional | require)
+    tls-verify-client "required"
+    tls-verify-client-depth 0
+    
+    ; possibility to use certificate revocation list
+    ; (none | leaf | chain)
+    tls-crl "leaf"
+    tls-crl-file "/usr/local/etc/wendzelnntpd/ssl/ssl.crl"
+</connector>
+```
+
+#### Mandatory TLS
+
+It is possible to make TLS mandatory with the parameter `tls-is-mandatory`.
+This is a global setting that will be applied to all connectors and needs
+to be set outside of the connectors.
+```ini
+tls-is-mandatory
+```
 
 ## Setting the Allowed Size of Postings
 
@@ -251,9 +322,9 @@ password-identification attacks when an equal password is used by
 multiple users. However, utilizing the username is less secure than
 having a completely separate salt for every password.[^2]
 
-### Encrypted communication (TLS)
+### Encrypted communication (TLS) and mutual authentication (mTLS)
 
-Please look at section [Network-Settings](#network-settings) when you want
-to use encryption over TLS.
+Please look at section [Encrypted connections over TLS](configuration.md#encrypted-connections-over-tls)
+when you want to use encryption and mutual authentication over TLS.
 
 [^2]: Patches are appreciated!

--- a/docs/docs/install.md
+++ b/docs/docs/install.md
@@ -41,22 +41,6 @@ $ make
 ...
 ```
 
-##### Generating SSL certifiates
-
-If you want to generate SSL certificates you can use the helper script:
-```console
-$ sudo create_certificate \
-    --environment letsencrypt \
-    --email <YOUR-EMAIL> \
-    --domain <YOUR-DOMAIN>
-```
-For the parameter `--environment`, "*local*" is also a valid value. In
-that case, the certificate is generated only for usage on localhost and
-is self-signed. After generating the certificate you have to adjust
-*wendzelnntpd.conf* (check Section [Network-Settings](configuration.md#network-settings))
-to activate TLS (configuration option *enable-tls*).
-The paths for certificate and server key can stay as they are.
-
 ##### Installing WendzelNNTPd
 
 To install WendzelNNTPd on your system, you need superuser access. Run
@@ -72,6 +56,27 @@ for an upgrade. Please cf. Section [Upgrading](upgrade.md#upgrading).
 was set up during `make install`. Please refer to
 Section [Basic Configuration](configuration.md#basic-configuration) to learn how to generate
 the MySQL database.
+
+##### Generating SSL certificates
+
+TLS is enabled by default in *wendzelnntpd.conf* as long as WendzelNNTPd has
+not been compiled without TLS support. `make install` generates a self-signed
+certificate for usage on localhost so that TLS can be used out-of-the-box.
+
+If you want to generate an SSL certificate, which is signed by Let's Encrypt,
+or a new self-signed certificate, you can use the helper script `create_certificate`:
+```console
+$ sudo create_certificate \
+    --environment letsencrypt \
+    --email <YOUR-EMAIL> \
+    --domain <YOUR-DOMAIN>
+```
+For the parameter `--environment`, "*local*" is also a valid value. In
+that case, the certificate is generated only for usage on localhost and
+is self-signed. The location of the generated certificates can be adjusted
+with the parameter `--targetdir`. You also need to adjust the paths in
+*wendzelnntpd.conf* if you use a non-default location
+(check Section [Network-Settings](configuration.md#network-settings)).
 
 ### Init Script for Automatic Startup
 

--- a/docs/docs/install.md
+++ b/docs/docs/install.md
@@ -76,7 +76,7 @@ that case, the certificate is generated only for usage on localhost and
 is self-signed. The location of the generated certificates can be adjusted
 with the parameter `--targetdir`. You also need to adjust the paths in
 *wendzelnntpd.conf* if you use a non-default location
-(check Section [Network-Settings](configuration.md#network-settings)).
+(check Section [Encrypted connections over TLS](configuration.md#encrypted-connections-over-tls)).
 
 ### Init Script for Automatic Startup
 

--- a/docs/docs/install.md
+++ b/docs/docs/install.md
@@ -45,7 +45,7 @@ $ make
 
 If you want to generate SSL certificates you can use the helper script:
 ```console
-$ sudo ./create_certificate \
+$ sudo create_certificate \
     --environment letsencrypt \
     --email <YOUR-EMAIL> \
     --domain <YOUR-DOMAIN>

--- a/docs/docs/running.md
+++ b/docs/docs/running.md
@@ -420,7 +420,7 @@ security of the server can be improved by putting WendzelNNTPd in a
 *chroot* environment or letting it run under an unprivileged user
 account (the user then needs write access to
 */var/spool/news/wendzelnntpd* and read access to
-(*/usr/local)/etc/wendzelnntpd.conf*). An unprivileged user under
+(*/usr/local)/etc/wendzelnntpd/wendzelnntpd.conf*). An unprivileged user under
 Unix-like systems is also not able to create a listen socket on the
 default NNTP port (119) since all ports up to 1023 are usually[^3]
 reserved. This means that the server should use a port

--- a/docs/docs/upgrade.md
+++ b/docs/docs/upgrade.md
@@ -5,6 +5,10 @@
 Please stop WendzelNNTPd and check the *wendzelnntpd.conf*. There is a
 new configuration style that breaks parts of the previous configuration
 style (especially due to the introduction of "connectors").
+Additionally, the configuration file has been moved into the subdirectory
+*wendzelnntpd*. So, for example, if the file was previously located at
+*/usr/local/etc/wendzelnntpd.conf*, it must now be moved to
+*/usr/local/etc/wendzelnntpd/wendzelnntpd.conf*.
 
 Existing user passwords will no longer work. You need to recreate all
 users and their passwords using **wendzelnntpadm**. Additionally, you

--- a/docs/template.tex
+++ b/docs/template.tex
@@ -55,6 +55,9 @@
 \newcommand{\VerbatimStringTok}[1]{\textcolor[rgb]{0.25,0.44,0.63}{#1}}
 \newcommand{\WarningTok}[1]{\textcolor[rgb]{0.38,0.63,0.69}{\textbf{\textit{#1}}}}
 
+\providecommand{\tightlist}{%
+  \setlength{\itemsep}{0pt}\setlength{\parskip}{0pt}}
+
 \title{WendzelNNTPd Version 2.2 Documentation}
 \author{Steffen Wendzel and contributors}
 

--- a/openssl.cnf
+++ b/openssl.cnf
@@ -24,8 +24,13 @@ basicConstraints     = CA:FALSE
 subjectKeyIdentifier = hash
 keyUsage             = digitalSignature, keyEncipherment
 extendedKeyUsage     = serverAuth
-subjectAltName = @alt_names
+subjectAltName       = @alt_names
 
 [alt_names]
 DNS.1 = localhost
 DNS.2 = 127.0.0.1
+
+[v3_ca]
+basicConstraints = critical,CA:true
+subjectKeyIdentifier = hash
+authorityKeyIdentifier = keyid:always,issuer

--- a/unittesting/README.md
+++ b/unittesting/README.md
@@ -16,10 +16,10 @@ The setup of the database can be done with the script `initialize_db.sh` which c
 initializes it with the test data. It also copies some files of existing posts to `/var/spool/news/wendzelnntpd`
 and creates the file nextmsgid there.
 `unittesting/wendzelnntpd.conf` contains the configuration as expected by the tests and needs to be copied to the
-location of the configuration file of `wendzelnntpd` (`/usr/local/etc/wendzelnntpd.conf` by default):
+location of the configuration file of `wendzelnntpd` (`/usr/local/etc/wendzelnntpd/wendzelnntpd.conf` by default):
 ```shell
 ./initialize_db.sh
-cp test-files/wendzelnntpd.conf /usr/local/etc/
+cp test-files/wendzelnntpd.conf /usr/local/etc/wendzelnntpd/
 ```
 
 Some of the tests are testing the TLS functionality of `wendzelnntpd` and require some certificates.
@@ -28,8 +28,8 @@ They can be generated with the scripts `create_certificate` and `create-client-c
 bash ./create_certificate --environment local
 cd unittesting
 mkdir tmp
-cp /usr/local/etc/ssl/ca.crt tmp/ca-self.crt
-cp /usr/local/etc/ssl/ca-key.pem tmp/ca-self.key
+cp /usr/local/etc/wendzelnntpd/ssl/ca.crt tmp/ca-self.crt
+cp /usr/local/etc/wendzelnntpd/ssl/ca-key.pem tmp/ca-self.key
 ./create-client-cert.sh
 ```
 

--- a/unittesting/README.md
+++ b/unittesting/README.md
@@ -22,10 +22,11 @@ location of the configuration file of `wendzelnntpd` (`/usr/local/etc/wendzelnnt
 cp test-files/wendzelnntpd.conf /usr/local/etc/wendzelnntpd/
 ```
 
-Some of the tests are testing the TLS functionality of `wendzelnntpd` and require some certificates.
-They can be generated with the scripts `create_certificate` and `create-client-cert.sh`:
+Some tests are testing the TLS functionality of `wendzelnntpd` and require some certificates.
+Most certificates are already generated during `make install` by the script `create_certificate`.
+Additionally, you need to copy the CA certificate to the directory `tmp` and generate client certificates
+with the script `create-client-cert.sh`:
 ```shell
-bash ./create_certificate --environment local
 cd unittesting
 mkdir tmp
 cp /usr/local/etc/wendzelnntpd/ssl/ca.crt tmp/ca-self.crt

--- a/unittesting/test-files/openssl.cnf
+++ b/unittesting/test-files/openssl.cnf
@@ -1,9 +1,0 @@
-[req]
-distinguished_name = req_distinguished_name
-
-[req_distinguished_name]
-
-[v3_ca]
-basicConstraints = critical,CA:true
-subjectKeyIdentifier = hash
-authorityKeyIdentifier = keyid:always,issuer

--- a/unittesting/test-files/wendzelnntpd.conf
+++ b/unittesting/test-files/wendzelnntpd.conf
@@ -5,7 +5,7 @@ database-password testpass
 
 <connector>
     enable-starttls
-    port		119
+    port        119
     listen	    0.0.0.0
     tls-server-certificate "/usr/local/etc/wendzelnntpd/ssl/server.crt"
     tls-server-key "/usr/local/etc/wendzelnntpd/ssl/server.key"
@@ -17,7 +17,7 @@ database-password testpass
 
 <connector>
     enable-starttls
-    port		119
+    port        119
     listen	    ::
     tls-server-certificate "/usr/local/etc/wendzelnntpd/ssl/server.crt"
     tls-server-key "/usr/local/etc/wendzelnntpd/ssl/server.key"
@@ -29,7 +29,7 @@ database-password testpass
 
 <connector>
     enable-tls
-    port		563
+    port        563
     listen	    0.0.0.0
     tls-server-certificate "/usr/local/etc/wendzelnntpd/ssl/server.crt"
     tls-server-key "/usr/local/etc/wendzelnntpd/ssl/server.key"
@@ -41,7 +41,7 @@ database-password testpass
 
 <connector>
     enable-tls
-    port		563
+    port        563
     listen	    ::
     tls-server-certificate "/usr/local/etc/wendzelnntpd/ssl/server.crt"
     tls-server-key "/usr/local/etc/wendzelnntpd/ssl/server.key"
@@ -54,7 +54,7 @@ database-password testpass
 ; mutual auth needed; tls-verify-client-depth = 0 cause of selfsigned certificate
 <connector>
     enable-tls
-    port		564
+    port        564
     listen	    0.0.0.0
 
     tls-server-certificate "/usr/local/etc/wendzelnntpd/ssl/server.crt"
@@ -72,7 +72,7 @@ database-password testpass
 ; mutual auth needed; tls-verify-client-depth = 0 cause of selfsigned certificate
 <connector>
     enable-tls
-    port		564
+    port        564
     listen	    ::
 
     tls-server-certificate "/usr/local/etc/wendzelnntpd/ssl/server.crt"

--- a/unittesting/test-files/wendzelnntpd.conf
+++ b/unittesting/test-files/wendzelnntpd.conf
@@ -7,9 +7,9 @@ database-password testpass
     enable-starttls
     port		119
     listen	    0.0.0.0
-    tls-server-certificate "/usr/local/etc/ssl/server.crt"
-    tls-server-key "/usr/local/etc/ssl/server.key"
-    tls-ca-certificate "/usr/local/etc/ssl/ca.crt"
+    tls-server-certificate "/usr/local/etc/wendzelnntpd/ssl/server.crt"
+    tls-server-key "/usr/local/etc/wendzelnntpd/ssl/server.key"
+    tls-ca-certificate "/usr/local/etc/wendzelnntpd/ssl/ca.crt"
     tls-cipher-suites "TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256"
     tls-ciphers "ALL:!COMPLEMENTOFDEFAULT:!eNULL"
     tls-version "1.2-1.3"
@@ -19,9 +19,9 @@ database-password testpass
     enable-starttls
     port		119
     listen	    ::
-    tls-server-certificate "/usr/local/etc/ssl/server.crt"
-    tls-server-key "/usr/local/etc/ssl/server.key"
-    tls-ca-certificate "/usr/local/etc/ssl/ca.crt"
+    tls-server-certificate "/usr/local/etc/wendzelnntpd/ssl/server.crt"
+    tls-server-key "/usr/local/etc/wendzelnntpd/ssl/server.key"
+    tls-ca-certificate "/usr/local/etc/wendzelnntpd/ssl/ca.crt"
     tls-cipher-suites "TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256"
     tls-ciphers "ALL:!COMPLEMENTOFDEFAULT:!eNULL"
     tls-version "1.2-1.3"
@@ -31,9 +31,9 @@ database-password testpass
     enable-tls
     port		563
     listen	    0.0.0.0
-    tls-server-certificate "/usr/local/etc/ssl/server.crt"
-    tls-server-key "/usr/local/etc/ssl/server.key"
-    tls-ca-certificate "/usr/local/etc/ssl/ca.crt"
+    tls-server-certificate "/usr/local/etc/wendzelnntpd/ssl/server.crt"
+    tls-server-key "/usr/local/etc/wendzelnntpd/ssl/server.key"
+    tls-ca-certificate "/usr/local/etc/wendzelnntpd/ssl/ca.crt"
     tls-cipher-suites "TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256"
     tls-ciphers "ALL:!COMPLEMENTOFDEFAULT:!eNULL"
     tls-version "1.2-1.3"
@@ -43,9 +43,9 @@ database-password testpass
     enable-tls
     port		563
     listen	    ::
-    tls-server-certificate "/usr/local/etc/ssl/server.crt"
-    tls-server-key "/usr/local/etc/ssl/server.key"
-    tls-ca-certificate "/usr/local/etc/ssl/ca.crt"
+    tls-server-certificate "/usr/local/etc/wendzelnntpd/ssl/server.crt"
+    tls-server-key "/usr/local/etc/wendzelnntpd/ssl/server.key"
+    tls-ca-certificate "/usr/local/etc/wendzelnntpd/ssl/ca.crt"
     tls-cipher-suites "TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256"
     tls-ciphers "ALL:!COMPLEMENTOFDEFAULT:!eNULL"
     tls-version "1.2-1.3"
@@ -57,9 +57,9 @@ database-password testpass
     port		564
     listen	    0.0.0.0
 
-    tls-server-certificate "/usr/local/etc/ssl/server.crt"
-    tls-server-key "/usr/local/etc/ssl/server.key"
-    tls-ca-certificate "/usr/local/etc/ssl/ca.crt"
+    tls-server-certificate "/usr/local/etc/wendzelnntpd/ssl/server.crt"
+    tls-server-key "/usr/local/etc/wendzelnntpd/ssl/server.key"
+    tls-ca-certificate "/usr/local/etc/wendzelnntpd/ssl/ca.crt"
     tls-cipher-suites "TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256"
     tls-ciphers "ALL:!COMPLEMENTOFDEFAULT:!eNULL"
     tls-version "1.3-1.3"
@@ -75,9 +75,9 @@ database-password testpass
     port		564
     listen	    ::
 
-    tls-server-certificate "/usr/local/etc/ssl/server.crt"
-    tls-server-key "/usr/local/etc/ssl/server.key"
-    tls-ca-certificate "/usr/local/etc/ssl/ca.crt"
+    tls-server-certificate "/usr/local/etc/wendzelnntpd/ssl/server.crt"
+    tls-server-key "/usr/local/etc/wendzelnntpd/ssl/server.key"
+    tls-ca-certificate "/usr/local/etc/wendzelnntpd/ssl/ca.crt"
     tls-cipher-suites "TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256"
     tls-ciphers "ALL:!COMPLEMENTOFDEFAULT:!eNULL"
     tls-version "1.3-1.3"

--- a/wendzelnntpd.conf_raw
+++ b/wendzelnntpd.conf_raw
@@ -29,7 +29,7 @@ database-password mypass
 
 <connector>
     ;; enables STARTTLS for this port
-    ;enable-starttls
+    enable-starttls
     port		119
     listen	    127.0.0.1
     ;; configure SSL server certificate
@@ -55,7 +55,7 @@ database-password mypass
 
 <connector>
     ;; enables STARTTLS for this port
-    ;enable-starttls
+    enable-starttls
     port		119
     listen	    ::1
     ;; configure SSL server certificate
@@ -81,7 +81,7 @@ database-password mypass
 
 <connector>
     ;; enables TLS for this port
-    ;enable-tls
+    enable-tls
     port		563
     listen	    127.0.0.1
     ;; configure SSL server certificate (required)
@@ -107,7 +107,7 @@ database-password mypass
 
 <connector>
     ;; enables TLS for this port
-    ;enable-tls
+    enable-tls
     port		563
     listen	    ::1
     ;; configure SSL server certificate

--- a/wendzelnntpd.conf_raw
+++ b/wendzelnntpd.conf_raw
@@ -33,11 +33,11 @@ database-password mypass
     port		119
     listen	    127.0.0.1
     ;; configure SSL server certificate
-    tls-server-certificate "/usr/local/etc/ssl/server.crt"
+    tls-server-certificate "@confdir@/ssl/server.crt"
     ;; configure SSL private key
-    tls-server-key "/usr/local/etc/ssl/server.key"
+    tls-server-key "@confdir@/ssl/server.key"
     ;; configure SSL CA certificate
-    tls-ca-certificate "/usr/local/etc/ssl/ca.crt"
+    tls-ca-certificate "@confdir@/ssl/ca.crt"
     ;; configure TLS ciphers for TLSv1.3
     tls-cipher-suites "TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256"
     ;; configure TLS ciphers for TLSv1.1 and TLSv1.2
@@ -50,7 +50,7 @@ database-password mypass
     ;tls-verify-client-depth 0
     ;; possibility to use certificate revocation list (none | leaf | chain)
     ;tls-crl "none"
-    ;tls-crl-file "/usr/local/etc/ssl/ssl.crl"
+    ;tls-crl-file "@confdir@/ssl/ssl.crl"
 </connector>
 
 <connector>
@@ -59,11 +59,11 @@ database-password mypass
     port		119
     listen	    ::1
     ;; configure SSL server certificate
-    tls-server-certificate "/usr/local/etc/ssl/server.crt"
+    tls-server-certificate "@confdir@/ssl/server.crt"
     ;; configure SSL private key
-    tls-server-key "/usr/local/etc/ssl/server.key"
+    tls-server-key "@confdir@/ssl/server.key"
     ;; configure SSL CA certificate
-    tls-ca-certificate "/usr/local/etc/ssl/ca.crt"
+    tls-ca-certificate "@confdir@/ssl/ca.crt"
     ;; configure TLS ciphers for TLSv1.3
     tls-cipher-suites "TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256"
     ;; configure TLS ciphers for TLSv1.1 and TLSv1.2
@@ -76,7 +76,7 @@ database-password mypass
     ;tls-verify-client-depth 0
     ;; possibility to use certificate revocation list (none | leaf | chain)
     ;tls-crl "none"
-    ;tls-crl-file "/usr/local/etc/ssl/ssl.crl"
+    ;tls-crl-file "@confdir@/ssl/ssl.crl"
 </connector>
 
 <connector>
@@ -85,11 +85,11 @@ database-password mypass
     port		563
     listen	    127.0.0.1
     ;; configure SSL server certificate (required)
-    tls-server-certificate "/usr/local/etc/ssl/server.crt"
+    tls-server-certificate "@confdir@/ssl/server.crt"
     ;; configure SSL private key (required)
-    tls-server-key "/usr/local/etc/ssl/server.key"
+    tls-server-key "@confdir@/ssl/server.key"
     ;; configure SSL CA certificate (required)
-    tls-ca-certificate "/usr/local/etc/ssl/ca.crt"
+    tls-ca-certificate "@confdir@/ssl/ca.crt"
     ;; configure TLS ciphers for TLSv1.3
     tls-cipher-suites "TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256"
     ;; configure TLS ciphers for TLSv1.1 and TLSv1.2
@@ -102,7 +102,7 @@ database-password mypass
     ;tls-verify-client-depth 0
     ;; possibility to use certificate revocation list (none | leaf | chain)
     ;tls-crl "none"
-    ;tls-crl-file "/usr/local/etc/ssl/ssl.crl"
+    ;tls-crl-file "@confdir@/ssl/ssl.crl"
 </connector>
 
 <connector>
@@ -111,11 +111,11 @@ database-password mypass
     port		563
     listen	    ::1
     ;; configure SSL server certificate
-    tls-server-certificate "/usr/local/etc/ssl/server.crt"
+    tls-server-certificate "@confdir@/ssl/server.crt"
     ;; configure SSL private key
-    tls-server-key "/usr/local/etc/ssl/server.key"
+    tls-server-key "@confdir@/ssl/server.key"
     ;; configure SSL CA certificate
-    tls-ca-certificate "/usr/local/etc/ssl/ca.crt"
+    tls-ca-certificate "@confdir@/ssl/ca.crt"
     ;; configure TLS ciphers for TLSv1.3
     tls-cipher-suites "TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256"
     ;; configure TLS ciphers for TLSv1.1 and TLSv1.2
@@ -128,7 +128,7 @@ database-password mypass
     ;tls-verify-client-depth 0
     ;; possibility to use certificate revocation list (none | leaf | chain)
     ;tls-crl "none"
-    ;tls-crl-file "/usr/local/etc/ssl/ssl.crl"
+    ;tls-crl-file "@confdir@/ssl/ssl.crl"
 </connector>
 
 ; Uncomment 'verbose-mode' if you want to find errors or if you

--- a/wendzelnntpd.conf_raw
+++ b/wendzelnntpd.conf_raw
@@ -30,7 +30,7 @@ database-password mypass
 <connector>
     ;; enables STARTTLS for this port
     enable-starttls
-    port		119
+    port        119
     listen	    127.0.0.1
     ;; configure SSL server certificate
     tls-server-certificate "@confdir@/ssl/server.crt"
@@ -56,7 +56,7 @@ database-password mypass
 <connector>
     ;; enables STARTTLS for this port
     enable-starttls
-    port		119
+    port        119
     listen	    ::1
     ;; configure SSL server certificate
     tls-server-certificate "@confdir@/ssl/server.crt"
@@ -82,7 +82,7 @@ database-password mypass
 <connector>
     ;; enables TLS for this port
     enable-tls
-    port		563
+    port        563
     listen	    127.0.0.1
     ;; configure SSL server certificate (required)
     tls-server-certificate "@confdir@/ssl/server.crt"
@@ -108,7 +108,7 @@ database-password mypass
 <connector>
     ;; enables TLS for this port
     enable-tls
-    port		563
+    port        563
     listen	    ::1
     ;; configure SSL server certificate
     tls-server-certificate "@confdir@/ssl/server.crt"

--- a/wendzelnntpd_dev.conf
+++ b/wendzelnntpd_dev.conf
@@ -32,14 +32,14 @@ database-password mypass
 
 ; Connector without encryption
 <connector>
-    port		118
+    port        118
     listen	    0.0.0.0
 </connector>
 
 <connector>
     ;enables STARTTLS for this port
     enable-starttls
-    port		119
+    port        119
     listen	    0.0.0.0
     ; configure SSL server certificate
     tls-server-certificate "/usr/local/etc/wendzelnntpd/ssl/server.crt"
@@ -57,7 +57,7 @@ database-password mypass
 
 <connector>
     enable-tls
-    port		563
+    port        563
     listen	    0.0.0.0
     tls-server-certificate "/usr/local/etc/wendzelnntpd/ssl/server.crt"
     tls-server-key "/usr/local/etc/wendzelnntpd/ssl/server.key"
@@ -71,7 +71,7 @@ database-password mypass
 ; mutual auth needed; tls-verify-client-depth = 0 cause of selfsigned certificate
 <connector>
     enable-tls
-    port		564
+    port        564
     listen	    0.0.0.0
 
     tls-server-certificate "/usr/local/etc/wendzelnntpd/ssl/server-self.crt"

--- a/wendzelnntpd_dev.conf
+++ b/wendzelnntpd_dev.conf
@@ -42,11 +42,11 @@ database-password mypass
     port		119
     listen	    0.0.0.0
     ; configure SSL server certificate
-    tls-server-certificate "/usr/local/etc/ssl/server.crt"
+    tls-server-certificate "/usr/local/etc/wendzelnntpd/ssl/server.crt"
     ; configure SSL private key
-    tls-server-key "/usr/local/etc/ssl/server.key"
+    tls-server-key "/usr/local/etc/wendzelnntpd/ssl/server.key"
     ; configure SSL CA certificate
-    tls-ca-certificate "/usr/local/etc/ssl/ca.crt"
+    tls-ca-certificate "/usr/local/etc/wendzelnntpd/ssl/ca.crt"
     ; configure TLS ciphers for TLSv1.3
     tls-cipher-suites "TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256"
     ; configure TLS ciphers for TLSv1.1 and TLSv1.2
@@ -59,9 +59,9 @@ database-password mypass
     enable-tls
     port		563
     listen	    0.0.0.0
-    tls-server-certificate "/usr/local/etc/ssl/server.crt"
-    tls-server-key "/usr/local/etc/ssl/server.key"
-    tls-ca-certificate "/usr/local/etc/ssl/ca.crt"
+    tls-server-certificate "/usr/local/etc/wendzelnntpd/ssl/server.crt"
+    tls-server-key "/usr/local/etc/wendzelnntpd/ssl/server.key"
+    tls-ca-certificate "/usr/local/etc/wendzelnntpd/ssl/ca.crt"
     tls-cipher-suites "TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256"
     tls-ciphers "ALL:!COMPLEMENTOFDEFAULT:!eNULL"
     tls-version "1.3-1.3"
@@ -74,9 +74,9 @@ database-password mypass
     port		564
     listen	    0.0.0.0
 
-    tls-server-certificate "/usr/local/etc/ssl/server-self.crt"
-    tls-server-key "/usr/local/etc/ssl/server-self.key"
-    tls-ca-certificate "/usr/local/etc/ssl/ca-self.crt"
+    tls-server-certificate "/usr/local/etc/wendzelnntpd/ssl/server-self.crt"
+    tls-server-key "/usr/local/etc/wendzelnntpd/ssl/server-self.key"
+    tls-ca-certificate "/usr/local/etc/wendzelnntpd/ssl/ca-self.crt"
     tls-cipher-suites "TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256"
     tls-ciphers "ALL:!COMPLEMENTOFDEFAULT:!eNULL"
     tls-version "1.3-1.3"
@@ -87,7 +87,7 @@ database-password mypass
 
     ; possibility to use certificate revocation list (none | leaf | chain)
     ;tls-crl "none"
-    ;tls-crl-file "/usr/local/etc/ssl/ssl.crl"
+    ;tls-crl-file "/usr/local/etc/wendzelnntpd/ssl/ssl.crl"
 </connector>
 ; Uncomment 'verbose-mode' if you want to find errors or if you
 ; have problems with the logging subsystem. All log strings are


### PR DESCRIPTION
This PR enables TLS by default during installation, the required certificates are also created by make install. The wendzelnntpd.conf is moved into the subdirectory wendzelnntpd so that the config and the certificates can be placed into the same subdirectory in /etc (the usage of a subdirectory is also recommended by the Filesystem Hierarchy Standard https://refspecs.linuxfoundation.org/FHS_3.0/fhs/ch03s07.html). The upgrade to version 2.2.0 is a good opportunity to move the file because users need to adapt the configuration to the new layout of the configuration file anyway.
The PR also add some improvements to the script create_certificate and the documentation regarding TLS.

List of changes:
- Enable starttls and tls in the wendzelnntpd.conf by default (the config options are silently ignored if WendzelNNTPd is compiled without TLS support)
- Create certificates for TLS in make install, if TLS is enabled and the creation is not disabled by the flag CREATE_CERTIFICATES
- CREATE_CERTIFICATES is enabled by default if TLS support is enabled. The flag can be used to disable the creation of the certificates during make install, which is useful for packaging, because the certificates must be created later during package installation not package creation
- Move wendzelnntpd.conf and certificates together into subdirectory (\@sysconfdir\@/wendzelnntpd/)
- install create_certificate (and openssl.cnf) if TLS is enabled alongside wendzelnntpd so that the script can be used for configuration after installation when the sources might not be available anymore e.g. for users of binary packages
- Add a man page for create_certificate (and install it during make install)
- Exit with statuscode 1 if create_certificate is not run with root privileges
- set -e in create_certificate so that the script fails if one of the commands fails
- Use the openssl.cnf from wendzelnntpd in all relevant openssl calls in create_certificate to make the script independent of the default openssl.cnf which might not exists depending on the distribution.
- Move the openssl.cnf from the docker subdirectory to the root directory because it is not exclusively used by the docker image.
- Make the target directory for the certificates in create_certificate configurable
- Adapt build-tests.yml, tests, dev Dockerfile and documentation to the changes.
- Extend documentation regarding TLS configuration