### PR TITLE
Add Dockerimage and publish it to Docker Hub

### DIFF
--- a/.github/workflows/docker-ci.yml
+++ b/.github/workflows/docker-ci.yml
@@ -2,9 +2,14 @@ name: Publish Docker image
 
 on:
   push:
+    branches:
+      - "**"
     tags:
-      - 'v*'
+      - "v*"
   workflow_dispatch:
+
+env:
+    TEST_TAG: wendzelnntpd:test
 
 jobs:
   push_to_registry:
@@ -24,8 +29,8 @@ jobs:
         with:
           images: ${{ secrets.DOCKER_USERNAME }}/wendzelnntpd
       - name: Build and push Docker image
-        id: push
         uses: docker/build-push-action@v6
+        if: ${{ startsWith(github.ref, 'refs/tags/v') }}
         with:
           context: .
           file: ./packages/docker/Dockerfile

--- a/.github/workflows/docker-ci.yml
+++ b/.github/workflows/docker-ci.yml
@@ -1,4 +1,4 @@
-name: Publish Docker image
+name: Test and publish Docker image
 
 on:
   push:
@@ -28,6 +28,17 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: ${{ secrets.DOCKER_USERNAME }}/wendzelnntpd
+      - name: Build and export to Docker
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./packages/docker/Dockerfile
+          load: true
+          tags: ${{ env.TEST_TAG }}
+      - name: Install test tools
+        run: sudo apt-get update -y && sudo apt-get install -y expect
+      - name: Test
+        run:  cd unittesting && ./test_dockerimage.sh ${{ env.TEST_TAG }}
       - name: Build and push Docker image
         uses: docker/build-push-action@v6
         if: ${{ startsWith(github.ref, 'refs/tags/v') }}

--- a/.github/workflows/docker-ci.yml
+++ b/.github/workflows/docker-ci.yml
@@ -1,0 +1,34 @@
+name: Publish Docker image
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+
+jobs:
+  push_to_registry:
+    name: Push Docker image to Docker Hub
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ secrets.DOCKER_USERNAME }}/wendzelnntpd
+      - name: Build and push Docker image
+        id: push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./packages/docker/Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ config.tab.h
 lex.yy.c
 .idea
 /unittesting/tmp/
+/unittesting/out/
 /create_certificate
 /docs/create_certificate.8
 /wendzelnntpd.conf

--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,7 @@ config.tab.c
 config.tab.h
 lex.yy.c
 .idea
-unittesting/tmp/
-create_certificate
-docs/create_certificate.8
-wendzelnntpd.conf
+/unittesting/tmp/
+/create_certificate
+/docs/create_certificate.8
+/wendzelnntpd.conf

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -20,6 +20,7 @@ ADDED FEATURES:
    the TLS implementation of WendzelNNTPd!
  - Docker environment for development purposes was provided by
    @SvenLie -- thanks for that!
+ - Add Docker image for production use
  - EXPERIMENTAL:
    - EXP: Added Postgres database support (experimental), thanks to
      Christian Barthel for providing a massive patch!

--- a/Makefile.in
+++ b/Makefile.in
@@ -255,10 +255,19 @@ man_wendzelnntpadm :
 	man -l test.man
 
 docker-build:
-	docker build -f ./docker/Dockerfile -t wendzelnntpd:latest .
+	docker build -f ./packages/docker/Dockerfile -t wendzelnntpd:latest .
 
 docker-run:
-	docker run --name wendzelnntpd --rm -it -p 118:118 -p 119:119 -p 563:563 -p 564:564 -v ${PWD}:/wendzelnntpd -v wendzelnntpd_data:/var/spool/news/wendzelnntpd wendzelnntpd:latest
+	docker run --name wendzelnntpd --rm -d -p 119:119 -p 563:563 -v wendzelnntpd_data:/var/spool/news/wendzelnntpd wendzelnntpd:latest
 
 docker-stop:
 	docker stop wendzelnntpd
+
+docker-dev-build:
+	docker build -f ./docker/Dockerfile -t wendzelnntpd-dev:latest .
+
+docker-dev-run:
+	docker run --name wendzelnntpd-dev --rm -it -p 118:118 -p 119:119 -p 563:563 -p 564:564 -v ${PWD}:/wendzelnntpd -v wendzelnntpd_dev_data:/var/spool/news/wendzelnntpd wendzelnntpd-dev:latest
+
+docker-dev-stop:
+	docker stop wendzelnntpd-dev

--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ The [Git repository's master branch](https://github.com/cdpxe/WendzelNNTPd) cont
      - Installation via `installpkg (filename)`
 - *NetBSD*:
   - WendzelNNTPd port at pkgsrc: [WendzelNNTPd-2.1.3](https://pkgsrc.se/wip/wendzelnntpd)
+- *Docker*:
+  - [cdpxe/wendzelnntpd](https://hub.docker.com/r/cdpxe/wendzelnntpd)
 - *Windows*:
   - Legacy WendzelNNTPd 1.4.6 branch: [WendzelNNTPd-1.4.6-Setup.exe](https://sourceforge.net/projects/wendzelnntpd/files/wendzelnntpd/1.4.6/)
 

--- a/docs/docs/development.md
+++ b/docs/docs/development.md
@@ -10,29 +10,29 @@ to run WendzelNNTPd in a Docker container.
 When you are on a UNIX-based system (like macOS) you can use the
 provided make commands:
 ```console
-$ make docker-build
-$ make docker-run
+$ make docker-dev-build
+$ make docker-dev-run
 ```
 
 To stop the Docker container you can use the following command:
 ```console
-$ make docker-stop
+$ make docker-dev-stop
 ```
 
 If you are not on a UNIX-based system (like Windows) use the following
 native docker commands:
 ```console
-$ docker build -f ./docker/Dockerfile -t wendzelnntpd:latest .
-$ docker run --name wendzelnntpd --rm -it \
+$ docker build -f ./docker/Dockerfile -t wendzelnntpd-dev:latest .
+$ docker run --name wendzelnntpd-dev --rm -it \
     -p 118:118 -p 119:119 -p 563:563 -p 564:564 \
     -v ${PWD}:/wendzelnntpd \
     -v wendzelnntpd_data:/var/spool/news/wendzelnntpd \
-    wendzelnntpd:latest
+    wendzelnntpd-dev:latest
 ```
 
 To stop the Docker container you can use the following command:
 ```console
-$ docker stop wendzelnntpd
+$ docker stop wendzelnntpd-dev
 ```
 
 ### Test new code

--- a/docs/docs/install.md
+++ b/docs/docs/install.md
@@ -2,7 +2,7 @@
 
 This chapter provides a guide on how to install WendzelNNTPd 2.x.
 
-## Linux/*nix/BSD
+## Linux/*nix/BSD from source
 
 To install WendzelNNTPd from source you can either [download the provided
 archive file of a stable version (e.g., *v-2.x.y.tar.gz*)](https://sourceforge.net/projects/wendzelnntpd/files/) and extract it or you can [clone the current WendzelNNTPd development repository](https://github.com/cdpxe/WendzelNNTPd).
@@ -82,6 +82,95 @@ with the parameter `--targetdir`. You also need to adjust the paths in
 
 There is an init script in the directory scripts/startup. It uses the
 usual parameters like "start", "stop" and "restart".
+
+## Docker image for Linux
+
+WendzelNNTPd is available as a [Docker image on Docker Hub](https://hub.docker.com/r/cdpxe/wendzelnntpd).
+
+##### Run WendzelNNTPd in a Docker container
+
+```console
+$ docker run --name wendzelnntpd -d -p 119:119 -p 563:563 cdpxe/wendzelnntpd
+```
+
+##### Specify volumes for the database and configuration files
+
+```console
+$ docker run --name my-wendzelnntpd -d -p 119:119 -p 563:563 \
+    -v wendzelnntpd_config:/usr/local/etc/wendzelnntpd \
+    -v wendzelnntpd_data:/var/spool/news/wendzelnntpd \
+    cdpxe/wendzelnntpd
+```
+
+##### Administration with wendzelnntpadm
+
+```console
+$ docker run --rm -v wendzelnntpd_config:/usr/local/etc/wendzelnntpd \
+    -v wendzelnntpd_data:/var/spool/news/wendzelnntpd \
+     cdpxe/wendzelnntpd wendzelnntpadm
+```
+Find further information regarding the administration of WendzelNNTPd in [Running](running.md#administration-tool-wendzelnntpadm).
+
+##### Create new certificates
+
+```console
+$ docker run --rm -v wendzelnntpd_config:/usr/local/etc/wendzelnntpd \
+    cdpxe/wendzelnntpd create_certificate
+```
+Finy further information in [Generating SSL certificates](#generating-ssl-certificates).
+
+##### Get the configuration file
+
+Copy the default configuration file from the image to the host:
+```console
+$ docker run --rm --entrypoint=cat cdpxe/wendzelnntpd \
+    /usr/local/etc/wendzelnntpd/wendzelnntpd.conf \
+    > /home/youruser/wendzelnntpd.conf
+```
+
+Or copy the current configuration file from your container:
+```console
+$ docker cp my-wendzelnntpd:/usr/local/etc/wendzelnntpd/wendzelnntpd.conf \
+    /home/youruser/wendzelnntpd.conf 
+```
+
+##### Edit the configuration file
+
+Find further information regarding the configuration of WendzelNNTPd in [Configuration](configuration.md#basic-configuration).
+
+##### Provide the configuration file to the container
+
+Copy the configuration file back to the container:
+```console
+$ docker cp /home/youruser/wendzelnntpd.conf \
+    my-wendzelnntpd:/usr/local/etc/wendzelnntpd/wendzelnntpd.conf
+```
+
+Or bind mount the configuration file (the file needs to be owned by root in this case):
+```console
+$ sudo chown 0:0 /home/youruser/wendzelnntpd.conf
+$ docker run --name wendzelnntpd -d -p 119:119 -p 563:563 \
+    -v wendzelnntpd_config:/usr/local/etc/wendzelnntpd \
+    -v wendzelnntpd_data:/var/spool/news/wendzelnntpd \
+    -v /home/youruser/wendzelnntpd.conf:\
+/usr/local/etc/wendzelnntpd/wendzelnntpd.conf:ro \
+     -d cdpxe/wendzelnntpd
+```
+
+Or build a new image with your configuration file:
+```dockerfile
+FROM cdpxe/wendzelnntpd
+COPY wendzelnntpd.conf /usr/local/etc/wendzelnntpd/wendzelnntpd.conf
+```
+
+##### Create the Docker image from source
+
+You can also build the Docker image from source instead of using the pre-built image from Docker Hub.
+Therefore, you need to get the source code of WendzelNNTPd like explained in [Linux/*nix/BSD from source](#linuxnixbsd-from-source).
+After that you can build the image with `make`:
+```console
+$ make docker-build
+```
 
 ## Unofficial Note: Mac OS X
 

--- a/packages/docker/Dockerfile
+++ b/packages/docker/Dockerfile
@@ -1,0 +1,55 @@
+FROM debian:stable-slim as build-env
+
+# install build dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    bison \
+    flex \
+    gcc \
+    libmariadb-dev-compat \
+    libmariadb-dev \
+    libmhash-dev \
+    libsqlite3-dev \
+    libssl-dev \
+    make \
+    openssl \
+    sqlite3
+
+COPY . /wendzelnntpd
+WORKDIR /wendzelnntpd
+
+RUN ./configure && make && make install CREATE_CERTIFICATES=NO
+
+
+FROM debian:stable-slim
+
+# install runtime dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libmariadb3 \
+    libmhash2 \
+    libsqlite3-0 \
+    libssl3 \
+    openssl \
+    tini \
+	&& apt-get clean \
+	&& rm -rf /var/lib/apt/lists/*
+
+# copy the binaries and other required data from the build environment
+COPY --from=build-env /usr/local/sbin/wendzelnntpd /usr/local/sbin/
+COPY --from=build-env /usr/local/sbin/wendzelnntpadm /usr/local/sbin/
+COPY --from=build-env /usr/local/sbin/create_certificate /usr/local/sbin/
+COPY --from=build-env /usr/local/share/wendzelnntpd/openssl.cnf /usr/local/share/wendzelnntpd/
+COPY --from=build-env /usr/local/etc/wendzelnntpd/wendzelnntpd.conf /usr/local/etc/wendzelnntpd/
+COPY --from=build-env /var/spool/news/wendzelnntpd/usenet.db /var/spool/news/wendzelnntpd/
+
+COPY packages/docker/wendzelnntpd.conf /usr/local/etc/wendzelnntpd/
+COPY packages/docker/docker-entrypoint.sh /
+
+RUN touch /var/log/wendzelnntpd
+
+VOLUME /var/spool/news/wendzelnntpd /usr/local/etc/wendzelnntpd
+
+EXPOSE 119
+EXPOSE 563
+
+ENTRYPOINT [ "tini", "--", "/docker-entrypoint.sh" ]
+CMD [ "wendzelnntpd" ]

--- a/packages/docker/Dockerfile
+++ b/packages/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stable-slim as build-env
+FROM debian:stable-slim AS build-env
 
 # install build dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/packages/docker/docker-entrypoint.sh
+++ b/packages/docker/docker-entrypoint.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+set -e
+
+if [ "$1" = "wendzelnntpd" ]
+then
+    if [ ! -e /usr/local/etc/wendzelnntpd/ssl/server.crt ] \
+        || [ ! -e /usr/local/etc/wendzelnntpd/ssl/server.key ] \
+        || [ ! -e /usr/local/etc/wendzelnntpd/ssl/ca.crt ]
+    then
+        create_certificate --environment local
+    fi
+fi
+
+exec "$@"

--- a/packages/docker/wendzelnntpd.conf
+++ b/packages/docker/wendzelnntpd.conf
@@ -1,0 +1,187 @@
+; WendzelNNTPd default configuration file
+;
+; Please note:
+;     By default, SQLite instead of MySQL is used; no
+;     authentication is activated and standard ports are used.
+;     Also, the server listens only on the localhost interface
+;     ("listen 127.0.0.1").
+
+;;;;;;; Fundamental setup ;;;;;;;
+; Specify a database engine. Currently supported are 'sqlite3'
+; and 'mysql' as well as experimental support for 'postgres'.
+database-engine sqlite3
+
+;;;;;;; MySQL-specific parameters ;;;;;;;
+; Your database hostname (not used in case of sqlite3).
+database-server 127.0.0.1
+; The database connection port (not used in case of sqlite3).
+; Comment out to use the default port of your database engine.
+database-port 3306
+; Server authentication (not required for sqlite3)
+database-username myuser
+database-password mypass
+
+;;;;;;; Network settings ;;;;;;;
+; You need to specify the port _before_ using the 'listen' command!
+; However, a mix like `port xyz, listen abc, port bca, listen zyb'
+; should work fine, i.e., assigning different ports to different
+; network interfaces.
+
+<connector>
+    ;; enables STARTTLS for this port
+    enable-starttls
+    port        119
+    listen	    0.0.0.0
+    ;; configure SSL server certificate
+    tls-server-certificate "/usr/local/etc/wendzelnntpd/ssl/server.crt"
+    ;; configure SSL private key
+    tls-server-key "/usr/local/etc/wendzelnntpd/ssl/server.key"
+    ;; configure SSL CA certificate
+    tls-ca-certificate "/usr/local/etc/wendzelnntpd/ssl/ca.crt"
+    ;; configure TLS ciphers for TLSv1.3
+    tls-cipher-suites "TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256"
+    ;; configure TLS ciphers for TLSv1.1 and TLSv1.2
+    tls-ciphers "ALL:!COMPLEMENTOFDEFAULT:!eNULL"
+    ;; configure allowed TLS version (1.0-1.3)
+    tls-version "1.2-1.3"
+    ;; possibility to force the client to authenticate with client certificate (none | optional | require)
+    ;tls-verify-client "required"
+    ;; define depth for checking client certificate
+    ;tls-verify-client-depth 0
+    ;; possibility to use certificate revocation list (none | leaf | chain)
+    ;tls-crl "none"
+    ;tls-crl-file "/usr/local/etc/wendzelnntpd/ssl/ssl.crl"
+</connector>
+
+;<connector>
+    ;; enables STARTTLS for this port
+    ;enable-starttls
+    ;port        119
+    ;listen	    ::
+    ;; configure SSL server certificate
+    ;tls-server-certificate "/usr/local/etc/wendzelnntpd/ssl/server.crt"
+    ;; configure SSL private key
+    ;tls-server-key "/usr/local/etc/wendzelnntpd/ssl/server.key"
+    ;; configure SSL CA certificate
+    ;tls-ca-certificate "/usr/local/etc/wendzelnntpd/ssl/ca.crt"
+    ;; configure TLS ciphers for TLSv1.3
+    ;tls-cipher-suites "TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256"
+    ;; configure TLS ciphers for TLSv1.1 and TLSv1.2
+    ;tls-ciphers "ALL:!COMPLEMENTOFDEFAULT:!eNULL"
+    ;; configure allowed TLS version (1.0-1.3)
+    ;tls-version "1.2-1.3"
+    ;; possibility to force the client to authenticate with client certificate (none | optional | require)
+    ;tls-verify-client "required"
+    ;; define depth for checking client certificate
+    ;tls-verify-client-depth 0
+    ;; possibility to use certificate revocation list (none | leaf | chain)
+    ;tls-crl "none"
+    ;tls-crl-file "/usr/local/etc/wendzelnntpd/ssl/ssl.crl"
+;</connector>
+
+<connector>
+    ;; enables TLS for this port
+    enable-tls
+    port        563
+    listen	    0.0.0.0
+    ;; configure SSL server certificate (required)
+    tls-server-certificate "/usr/local/etc/wendzelnntpd/ssl/server.crt"
+    ;; configure SSL private key (required)
+    tls-server-key "/usr/local/etc/wendzelnntpd/ssl/server.key"
+    ;; configure SSL CA certificate (required)
+    tls-ca-certificate "/usr/local/etc/wendzelnntpd/ssl/ca.crt"
+    ;; configure TLS ciphers for TLSv1.3
+    tls-cipher-suites "TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256"
+    ;; configure TLS ciphers for TLSv1.1 and TLSv1.2
+    tls-ciphers "ALL:!COMPLEMENTOFDEFAULT:!eNULL"
+    ;; configure allowed TLS version (1.0-1.3)
+    tls-version "1.2-1.3"
+    ;; possibility to force the client to authenticate with client certificate (none | optional | require)
+    ;tls-verify-client "required"
+    ;; define depth for checking client certificate
+    ;tls-verify-client-depth 0
+    ;; possibility to use certificate revocation list (none | leaf | chain)
+    ;tls-crl "none"
+    ;tls-crl-file "/usr/local/etc/wendzelnntpd/ssl/ssl.crl"
+</connector>
+
+;<connector>
+    ;; enables TLS for this port
+    ;enable-tls
+    ;port        563
+    ;listen	    ::
+    ;; configure SSL server certificate
+    ;tls-server-certificate "/usr/local/etc/wendzelnntpd/ssl/server.crt"
+    ;; configure SSL private key
+    ;tls-server-key "/usr/local/etc/wendzelnntpd/ssl/server.key"
+    ;; configure SSL CA certificate
+    ;tls-ca-certificate "/usr/local/etc/wendzelnntpd/ssl/ca.crt"
+    ;; configure TLS ciphers for TLSv1.3
+    ;tls-cipher-suites "TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256"
+    ;; configure TLS ciphers for TLSv1.1 and TLSv1.2
+    ;tls-ciphers "ALL:!COMPLEMENTOFDEFAULT:!eNULL"
+    ;; configure allowed TLS version (1.0-1.3)
+    ;tls-version "1.2-1.3"
+    ;; possibility to force the client to authenticate with client certificate (none | optional | require)
+    ;tls-verify-client "required"
+    ;; define depth for checking client certificate
+    ;tls-verify-client-depth 0
+    ;; possibility to use certificate revocation list (none | leaf | chain)
+    ;tls-crl "none"
+    ;tls-crl-file "/usr/local/etc/wendzelnntpd/ssl/ssl.crl"
+;</connector>
+
+; Uncomment 'verbose-mode' if you want to find errors or if you
+; have problems with the logging subsystem. All log strings are
+; written to STDERR, too, if verbose-mode is activated.
+; Additionally all commands sent by clients are written to STDERR
+; (but not to the logfile).
+;verbose-mode
+
+;;;;;;; Advanced settings ;;;;;;;
+; The max. allowed size of a single posting (in bytes). The
+; default value is 20 MBytes (20*1024^2=20.971.520 Bytes).
+max-size-of-postings 20971520
+
+; Activate authentication.
+;use-authentication
+
+; Store the Message Body in the database (only possible
+; with postgres!).
+; !!! This setting should NOT be changed after initial utilization
+; of the server as old message bodies would not be locatable
+; anymore!
+; Default: store the message body in the filesystem
+;message-body-in-db
+
+; Store/load the unique message index within the database
+; system. (Only possible with postgres!)
+; !!! This should NOT be changed after initial utilization of
+; the server as the message counter would be corrupted otherwise!
+; Deactivated by default.
+;message-count-in-db
+
+; If you activated authentication (above, using the keyword
+; `use-authentication'), you can also activate the support for
+; access control lists (ACL).
+;use-acl
+
+; This keyword prevents that IPs or hostnames will become part of
+; the message ID generated by WendzelNNTPd (what is the default
+; case). Uncomment `enable-anonym-mids' to enable this feature.
+;enable-anonym-mids
+
+; This keyword defines a salt to be used in conjunction with the
+; passwords to calculate the cryptographic hashes. The salt must
+; be in the form [a-zA-Z0-9.:\/-_]+.
+; Please note that the final hash is calculated using
+; salt+username+password as an input to prevent simple
+; password-identification attacks when an equal password is used
+; by >=2 users.
+; ATTENTION: If you change the salt after passwords have been
+; stored, they will be rendered invalid! If you comment out
+; hash-salt, then the default hash salt defined in the source
+; code will be used.
+; You should change the default hash-salt value before first use!
+hash-salt 0.hG4//3baA-::_\
+

--- a/unittesting/README.md
+++ b/unittesting/README.md
@@ -6,6 +6,7 @@ The subdirectory [tests](tests) contains scripts, which use the `expect` command
 and need a properly configured and initialized `wendzelnntpd` server.
 The script `run.sh` can be used to run the tests, but they can also be executed individually.
 The testing of `wendzelnntpadm` is done by the script `test_wendzelnntpadm.sh`.
+The testing of the Docker image for WendzelNNTPd is done by the script `test_dockerimage.sh`.
 
 ## Setup of the testing environment
 
@@ -115,4 +116,14 @@ mysql --host=127.0.0.1 --user=root --password=rootpass --execute "set session sq
 Example for initializing a PostgreSQL database:
 ```shell
 psql postgresql://testuser:testpass@127.0.0.1:5432/wendzelnntpd --file database/postgres_db_struct.sql --file unittesting/create_db_test_data.sql
+```
+
+## Execution of the tests for the Docker image
+
+You need to build the Docker image with `make docker-build` before running the tests.
+These tests require no further setup of the testing environment.
+```shell
+make docker-build
+cd unittesting/
+./test_dockerimage.sh
 ```

--- a/unittesting/test_dockerimage.sh
+++ b/unittesting/test_dockerimage.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+image="${1:-wendzelnntpd}"
+
+check_returncode() {
+    actual=$1
+    expected=$2
+    if [ "$actual" -ne "$expected" ]
+    then
+        echo "Failure"
+        echo "Expected returncode $expected but was $actual"
+        echo "Output:"
+        echo "$3"
+        exit 1
+    fi
+}
+
+echo "== Test wendzelnntp"
+#docker run --name wendzelnntpd --rm -d -p 119:119 -p 563:563 wendzelnntpd
+output=$(docker run --name "$image" --rm -d -p 119:119 -p 563:563 wendzelnntpd 2>&1)
+returncode=$?
+check_returncode $returncode 0 "$output"
+
+echo "= Check connection to wendzelnntpd"
+nntp_address=localhost expect tests/nntp-help-test.exp
+returncode=$?
+check_returncode $returncode 0
+
+docker stop wendzelnntpd
+
+echo "== Test wendzelnntpadm"
+output=$(docker run --rm "$image" wendzelnntpadm listgroups 2>&1)
+returncode=$?
+check_returncode $returncode 0 "$output"
+
+echo "= Check whether the group which gets created by default exists"
+if ! echo "$output" | grep -q -- "alt.wendzelnntpd.test"
+then
+	echo "Failure"
+	echo "Can't find group alt.wendzelnntpd.test"
+	echo "Received output:"
+	echo "$output"
+	exit 1
+fi
+
+echo "== Test create_certificate"
+output=$(docker run --rm -v "$(pwd)"/out:/usr/local/etc/wendzelnntpd/ssl "$image" create_certificate)
+returncode=$?
+check_returncode $returncode 0 "$output"
+
+echo "= Check certificates"
+if [ ! -f out/server.crt ] || [ ! -f out/server.key ] || [ ! -f out/ca.crt ]
+then
+	echo "Can't find certificates in out/"
+	exit 1
+fi

--- a/unittesting/test_dockerimage.sh
+++ b/unittesting/test_dockerimage.sh
@@ -15,8 +15,7 @@ check_returncode() {
 }
 
 echo "== Test wendzelnntp"
-#docker run --name wendzelnntpd --rm -d -p 119:119 -p 563:563 wendzelnntpd
-output=$(docker run --name "$image" --rm -d -p 119:119 -p 563:563 wendzelnntpd 2>&1)
+output=$(docker run --name wendzelnntpd --rm -d -p 119:119 -p 563:563 "$image" 2>&1)
 returncode=$?
 check_returncode $returncode 0 "$output"
 


### PR DESCRIPTION
This PR adds a new Dockerfile for WendzelNNTPd which is intended for production purposes in contrary to the existing Dockerfile which is intended for development purposes. The PR also adds a GitHub Workflow which builds the Docker image from the Dockerfile and publishes it to Docker Hub if it belongs to a Tag.

This PR requires credentials of an account for Docker Hub to be able to push the Image to Docker Hub. Alternatively I could change the Workflow to push the Image to the container registry of GitHub instead, if you do not wan't to create an account for Docker Hub. The downside would be, that the Image wouldn't be discoverable on Docker Hub (the default container registry for Docker).

Details about the new Images and the changes:

- The Dockerimage contains the binaries wendzelnntpd, wendzelnntpadm and create_certificate. It also contains the files wendzelnntpd.conf and openssl.cnf and the prepared sqlite-database usenet.db.
- This makes it possible to also use the Dockerimage to run wendzelnntpadm and create_certificate for administration purposes
- The image starts the wendzelnntpd server by default
- TLS is enabled out-of-the-box
- The certificates are created during the startup of the container. The container starts therefore the wrapper-script docker-entrypoint.sh instead of wendzelnntpd directly.
- The Image uses `tini` (a tiny init system for containers) instead of calling docker-entrypoint.sh to ensure the correct handling of unix signals.
- wendzelnntpd is configured to only listen on IPv4 by default, because IPv6 is disabled in the default bridge network of Docker. wendzelnntpd would not start on such systems, if IPv6 would be included in the configuration.
- The Image uses volumes to store configuration files and the database.
- The Dockerfile uses a multi-stage build and copies the required files from the build environment to the final image, so that the final image only contains the runtime dependencies, not the build dependencies.
- The workflow for building, testing and pushing of the Docker image is triggered by pushes to all branches and by new tags which start with "v".
- The workflow builds the image, does some basic testing for wendzelnntpd, wendzelnntpadm and create_certificate and pushes the image to Docker Hub. The push to Docker Hub is only done when the workflow was triggered by a new tag starting with "v", so that only releases of WendzelNNTPd are pushed to Docker Hub.
- Add documentation about the Docker image
- Add new make targets for the new Dockerimage, rename the targets for the Dockerimage for development purposes from "docker" to "docker-dev"

As mentioned before, this PR requires credentials to Docker Hub to be able to push the image. Here are the steps to provide the credentials:
1. Create a new Docker Hub account [here](https://app.docker.com/signup) in case you don't already have one. When writing the documentation I assumed that the username would be "cdpxe" like your username on GitHub. The documentation needs to be changed in case you choose another name.
2. Sign into your Docker Hub account and create a new personal access token in your Account settings with the permissions "read+write". (for more details see [here](https://docs.docker.com/security/access-tokens/))
3. Add the following new secrets to this GitHub repository (under settings -> secrets and variables -> actions -> new repository secret).
    - DOCKER_USERNAME: the username of your Docker Hub account.
    - DOCKER_PASSWORD: the access token from the previous step (not your password)
4. Create a new repository named "wendzelnntpd" on Docker Hub ([here](https://hub.docker.com/repositories)). This step is optional, the repository is created automatically when the Workflow pushes the Image to Docker Hub for the first time.
5. Add a description, category and overview to the repository. I prepared a suggestion for them below. More information about this can be found [here](https://docs.docker.com/docker-hub/repos/manage/information/).

[Here](https://hub.docker.com/r/oleludwig/wendzelnntpd) you can see how the resulting page on Docker Hub for the Image would look like (pushed from my fork of WendzelNNTPd).

Repository Name: wendzelnntpd
Short description: WendzelNNTPd is an easy to configure Usenet server (NNTP daemon)
Categories: Networking
Repository overview (written in Markdown): [repository_overview.md](https://github.com/user-attachments/files/22568536/repository_overview.md)
