### PR TITLE
Add make target and documentation to help with uninstalling WendzelNNTPd

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -249,7 +249,8 @@ uninstall :
 	-rmdir --ignore-fail-on-non-empty $(DESTDIR)$(UDBDIR)
 	@echo
 	@echo "Uninstall finished. Please note that the wendzelnntpd.conf (and possibly backups of it) and ssl certificates are left in place under $(DESTDIR)$(confdir)."
-	@echo "The database (and possibly backups) and other user data like articles are also left in place under $(UDBDIR). You might consider deleting them now."
+	@echo "The database (and possibly backups) and other user data like articles are also left in place under $(UDBDIR)."
+	@echo "The log file /var/log/wendzelnntpd is also left in place. You might consider deleting them now."
 
 exec : bin/wendzelnntpd
 	./bin/wendzelnntpd

--- a/Makefile.in
+++ b/Makefile.in
@@ -226,6 +226,31 @@ upgrade : bin/wendzelnntpd bin/wendzelnntpadm
 	$(INSTALL_DATA) $(MANPAGES) $(DESTDIR)$(man8dir)
 	@echo "Upgrade finished. Thank you for upgrading and using this software. Have fun!"
 
+uninstall :
+	# binaries
+	-rm -f $(DESTDIR)$(sbindir)/wendzelnntpd
+	-rm -f $(DESTDIR)$(sbindir)/wendzelnntpadm
+	-rm -f $(DESTDIR)$(sbindir)/create_certificate
+	# data files
+	-rm -f $(DESTDIR)$(package_datadir)/openssl.cnf
+	# documentation
+	-cd $(DESTDIR)$(docdir)/ && rm -f $(notdir $(DOCFILES_TO_INST))
+	-rm -f $(DESTDIR)$(docdir)/docs.pdf
+	-rm -rf $(DESTDIR)$(docdir)/site/
+	# manpages
+	-cd $(DESTDIR)$(man8dir) && rm -f $(notdir $(MANPAGES))
+	# directories
+	-rmdir --ignore-fail-on-non-empty $(DESTDIR)$(confdir)
+	-rmdir --ignore-fail-on-non-empty $(DESTDIR)$(sbindir)
+	-rmdir --ignore-fail-on-non-empty $(DESTDIR)$(package_datadir)
+	-rmdir --ignore-fail-on-non-empty $(DESTDIR)$(docdir)
+	-rmdir --ignore-fail-on-non-empty $(DESTDIR)$(man8dir)
+	-rmdir --ignore-fail-on-non-empty $(DESTDIR)$(mandir)
+	-rmdir --ignore-fail-on-non-empty $(DESTDIR)$(UDBDIR)
+	@echo
+	@echo "Uninstall finished. Please note that the wendzelnntpd.conf (and possibly backups of it) and ssl certificates are left in place under $(DESTDIR)$(confdir)."
+	@echo "The database (and possibly backups) and other user data like articles are also left in place under $(UDBDIR). You might consider deleting them now."
+
 exec : bin/wendzelnntpd
 	./bin/wendzelnntpd
 

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,6 +1,6 @@
 # List of the mardown files which should be included in the pdf documentation.
 # The order of the files corresponds to the order of the chapters in the PDF.
-DOCFILES=docs/index.md docs/install.md docs/configuration.md docs/running.md docs/development.md docs/upgrade.md
+DOCFILES=docs/index.md docs/install.md docs/configuration.md docs/running.md docs/development.md docs/upgrade.md docs/uninstall.md
 
 all : site docs.pdf
 

--- a/docs/docs/uninstall.md
+++ b/docs/docs/uninstall.md
@@ -1,0 +1,13 @@
+# Uninstallation
+
+WendzelNNTPd can be uninstalled with `make uninstall` if you installed it from source.
+`./configure` needs to be called with the same parameters as during installation.
+You need superuser access to uninstall WendzelNNTPd.
+It is recommended to use the same version of the sources of WendzelNNTPd as the one installed.
+The configuration files, SQLite database, postings and log files are left in place to prevent data loss.
+You need to remove them manually if desired.
+
+```console
+$ ./configure
+$ sudo make uninstall
+```

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -6,6 +6,7 @@ nav:
   - Running: running.md
   - Development: development.md
   - Upgrade: upgrade.md
+  - Uninstallation: uninstall.md
 theme: readthedocs
 repo_url: https://github.com/cdpxe/WendzelNNTPd
 edit_uri: edit/master/docs/docs/


### PR DESCRIPTION
This PR adds `make uninstall` and a new chapter in the documentation to help with uninstalling WendzelNNTPd for users who installed WendzelNNTPd from source. It is also helpful for development purposes to revert most of the changes from `make install`.  The configuration files, SQLite database, postings and log files are left in place to prevent data loss.