### PR TITLE
Fix make uninstall on BSD systems

### DIFF
--- a/.github/workflows/build-tests.yml
+++ b/.github/workflows/build-tests.yml
@@ -199,6 +199,16 @@ jobs:
         run: cd unittesting && nntp_address=${{ env.ipv4 }} ./run.sh
       - name: expect tests IPv6
         run: cd unittesting && nntp_address=${{ env.ipv6 }} ./run.sh
+      - name: make uninstall
+        run: docker exec testcontainer bash -c "make uninstall"
+      - name: Check if directories/files are removed
+        run: >
+          docker exec testcontainer bash -c "
+          if [ -d '/usr/local/sbin/wendzelnntpd' ]; then echo '/usr/local/sbin/wendzelnntpd still exists'; exit 1; fi
+          && if [ -d '/usr/local/sbin/wendzelnntpadm' ]; then echo '/usr/local/sbin/wendzelnntpadm still exists'; exit 1; fi
+          && if [ -d '/usr/local/sbin/create_certificate' ]; then echo '/usr/local/sbin/create_certificate still exists'; exit 1; fi
+          && if [ -d '/usr/local/share/wendzelnntpd/' ]; then echo '/usr/local/share/wendzelnntpd/ still exists'; exit 1; fi
+          && if [ -d '/usr/local/doc/wendzelnntpd/' ]; then echo '/usr/local/doc/wendzelnntpd/ still exists'; exit 1; fi"
       - name: Stop Docker container
         run: docker stop testcontainer -t 1
 
@@ -413,3 +423,12 @@ jobs:
         run: cd unittesting && nntp_address=${{ env.ipv4 }} ./run.sh
       - name: expect tests IPv6
         run: cd unittesting && nntp_address=${{ env.ipv6 }} ./run.sh
+      - name: make uninstall
+        shell: vm {0}
+        run: cd $GITHUB_WORKSPACE/ && make uninstall
+      - name: Check if directories are removed
+        shell: vm {0}
+        run: |
+          if [ -d "/usr/local/sbin/" ]; then echo "/usr/local/sbin/ still exists"; exit 1; fi
+          if [ -d "/usr/local/share/wendzelnntpd/" ]; then echo "/usr/local/share/wendzelnntpd/ still exists"; exit 1; fi
+          if [ -d "/usr/local/doc/wendzelnntpd/" ]; then echo "/usr/local/doc/wendzelnntpd/ still exists"; exit 1; fi

--- a/.github/workflows/build-tests.yml
+++ b/.github/workflows/build-tests.yml
@@ -208,7 +208,7 @@ jobs:
           && if [ -d '/usr/local/sbin/wendzelnntpadm' ]; then echo '/usr/local/sbin/wendzelnntpadm still exists'; exit 1; fi
           && if [ -d '/usr/local/sbin/create_certificate' ]; then echo '/usr/local/sbin/create_certificate still exists'; exit 1; fi
           && if [ -d '/usr/local/share/wendzelnntpd/' ]; then echo '/usr/local/share/wendzelnntpd/ still exists'; exit 1; fi
-          && if [ -d '/usr/local/doc/wendzelnntpd/' ]; then echo '/usr/local/doc/wendzelnntpd/ still exists'; exit 1; fi"
+          && if [ -d '/usr/local/share/doc/wendzelnntpd/' ]; then echo '/usr/local/share/doc/wendzelnntpd/ still exists'; exit 1; fi"
       - name: Stop Docker container
         run: docker stop testcontainer -t 1
 
@@ -429,6 +429,8 @@ jobs:
       - name: Check if directories are removed
         shell: vm {0}
         run: |
-          if [ -d "/usr/local/sbin/" ]; then echo "/usr/local/sbin/ still exists"; exit 1; fi
+          if [ -d '/usr/local/sbin/wendzelnntpd' ]; then echo '/usr/local/sbin/wendzelnntpd still exists'; exit 1; fi
+          if [ -d '/usr/local/sbin/wendzelnntpadm' ]; then echo '/usr/local/sbin/wendzelnntpadm still exists'; exit 1; fi
+          if [ -d '/usr/local/sbin/create_certificate' ]; then echo '/usr/local/sbin/create_certificate still exists'; exit 1; fi
           if [ -d "/usr/local/share/wendzelnntpd/" ]; then echo "/usr/local/share/wendzelnntpd/ still exists"; exit 1; fi
-          if [ -d "/usr/local/doc/wendzelnntpd/" ]; then echo "/usr/local/doc/wendzelnntpd/ still exists"; exit 1; fi
+          if [ -d "/usr/local/share/doc/wendzelnntpd/" ]; then echo "/usr/local/share/doc/wendzelnntpd/ still exists"; exit 1; fi

--- a/Makefile.in
+++ b/Makefile.in
@@ -240,13 +240,13 @@ uninstall :
 	# manpages
 	-cd $(DESTDIR)$(man8dir) && rm -f $(notdir $(MANPAGES))
 	# directories
-	-rmdir --ignore-fail-on-non-empty $(DESTDIR)$(confdir)
-	-rmdir --ignore-fail-on-non-empty $(DESTDIR)$(sbindir)
-	-rmdir --ignore-fail-on-non-empty $(DESTDIR)$(package_datadir)
-	-rmdir --ignore-fail-on-non-empty $(DESTDIR)$(docdir)
-	-rmdir --ignore-fail-on-non-empty $(DESTDIR)$(man8dir)
-	-rmdir --ignore-fail-on-non-empty $(DESTDIR)$(mandir)
-	-rmdir --ignore-fail-on-non-empty $(DESTDIR)$(UDBDIR)
+	-rmdir $(DESTDIR)$(confdir)
+	-rmdir $(DESTDIR)$(sbindir)
+	-rmdir $(DESTDIR)$(package_datadir)
+	-rmdir $(DESTDIR)$(docdir)
+	-rmdir $(DESTDIR)$(man8dir)
+	-rmdir $(DESTDIR)$(mandir)
+	-rmdir $(DESTDIR)$(UDBDIR)
 	@echo
 	@echo "Uninstall finished. Please note that the wendzelnntpd.conf (and possibly backups of it) and ssl certificates are left in place under $(DESTDIR)$(confdir)."
 	@echo "The database (and possibly backups) and other user data like articles are also left in place under $(UDBDIR)."

--- a/Makefile.in
+++ b/Makefile.in
@@ -65,7 +65,6 @@ DEBUG=$(GDBON) -DDEBUG -DXXDEBUG
 # The list of documentation files we wish to install
 DOCFILES_TO_INST=AUTHORS CHANGELOG HISTORY README.md INSTALL LICENSE database/usenet.db_struct database/mysql_db_struct.sql
 MANPAGES=docs/wendzelnntpd.8 docs/wendzelnntpadm.8 docs/create_certificate.8
-HTML_DOC_DIRS=$(shell cd docs/ && find site/ -type d)
 
 all : wendzelnntpadm main.o log.o database.o cdpstrings.o server.o lexyacc charstack.o libfunc.o acl.o db_abstraction.o hash.o $(SQLITEOBJ) $(MYSQLOBJ) $(POSTGRESOBJ) $(OPENSSLOBJ) globals.o scripts/startup/init.d_script create_certificate docs/create_certificate.8 wendzelnntpd.conf
 	expr `cat build` \+ 1 >build
@@ -234,11 +233,15 @@ uninstall :
 	# data files
 	-rm -f $(DESTDIR)$(package_datadir)/openssl.cnf
 	# documentation
-	-cd $(DESTDIR)$(docdir)/ && rm -f $(notdir $(DOCFILES_TO_INST))
+	-cd $(DESTDIR)$(docdir)/ && for f in $(DOCFILES_TO_INST); do \
+    	rm -f `basename $$f`; \
+	done
 	-rm -f $(DESTDIR)$(docdir)/docs.pdf
 	-rm -rf $(DESTDIR)$(docdir)/site/
 	# manpages
-	-cd $(DESTDIR)$(man8dir) && rm -f $(notdir $(MANPAGES))
+	-cd $(DESTDIR)$(man8dir) && for f in $(MANPAGES); do \
+    	rm -f `basename $$f`; \
+	done
 	# directories
 	-rmdir $(DESTDIR)$(confdir)
 	-rmdir $(DESTDIR)$(sbindir)


### PR DESCRIPTION
This PR makes the new `make uninstall` target (added in #56) compatible with BSD systems and adds tests to the github workflow to prevent such mistakes.

- Remove flags `--ignore-fail-on-non-empty` because it is not part of the POSIX standard and not supported by `rmdir` on BSD systems (it wasn't really required anyway, because failures from `rmdir`  are ignored in the Makefile. It just made the output nicer, in case that the directory wasn't empty)
- Remove `notdir` from the Makefile because it is only supported by gnu make not bsd make