### PR TITLE
Add systemd service unit for wendzelnntpd

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ autom4te.cache
 /config.sub
 
 scripts/startup/init.d_script
+scripts/startup/wendzelnntpd.service
 test.man
 *.o
 bin/wendzelnntpadm

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -154,6 +154,7 @@ MISC:
  - Move wendzelnntpd.conf into the subdirectory wendzelnntpd together
    with the SSL certificates, so the new default location for
    wendzelnntpd.conf is /usr/local/etc/wendzelnntpd/wendzelnntpd.conf.
+ - Add systemd service unit for wendzelnntpd
 
 2.1.3-stable "Friedrichroda" : 17-Apr-2021:
  As usual, every new release gets named after a nice travel location.

--- a/Makefile.in
+++ b/Makefile.in
@@ -66,7 +66,7 @@ DEBUG=$(GDBON) -DDEBUG -DXXDEBUG
 DOCFILES_TO_INST=AUTHORS CHANGELOG HISTORY README.md INSTALL LICENSE database/usenet.db_struct database/mysql_db_struct.sql
 MANPAGES=docs/wendzelnntpd.8 docs/wendzelnntpadm.8 docs/create_certificate.8
 
-all : wendzelnntpadm main.o log.o database.o cdpstrings.o server.o lexyacc charstack.o libfunc.o acl.o db_abstraction.o hash.o $(SQLITEOBJ) $(MYSQLOBJ) $(POSTGRESOBJ) $(OPENSSLOBJ) globals.o scripts/startup/init.d_script create_certificate docs/create_certificate.8 wendzelnntpd.conf
+all : wendzelnntpadm main.o log.o database.o cdpstrings.o server.o lexyacc charstack.o libfunc.o acl.o db_abstraction.o hash.o $(SQLITEOBJ) $(MYSQLOBJ) $(POSTGRESOBJ) $(OPENSSLOBJ) globals.o scripts/startup/init.d_script scripts/startup/wendzelnntpd.service create_certificate docs/create_certificate.8 wendzelnntpd.conf
 	expr `cat build` \+ 1 >build
 	$(CC) $(DEBUG) $(CFLAGS) $(LDFLAGS) -o bin/wendzelnntpd main.o log.o server.o lex.yy.o config.tab.o database.o globals.o cdpstrings.o acl.o db_abstraction.o hash.o $(SQLITEOBJ) $(MYSQLOBJ) $(POSTGRESOBJ) charstack.o libfunc.o $(OPENSSLOBJ) $(LIBS)
 	#strip bin/wendzelnntpd
@@ -141,6 +141,9 @@ wendzelnntpadm : cdpnntpadm.o db_abstraction.o $(SQLITEOBJ) $(MYSQLOBJ) $(POSTGR
 	#strip bin/wendzelnntpadm
 
 scripts/startup/init.d_script : Makefile $(srcdir)/scripts/startup/init.d_script_raw
+	sed -e 's|@sbindir[@]|$(sbindir)|g' $@_raw > $@
+
+scripts/startup/wendzelnntpd.service : Makefile $(srcdir)/scripts/startup/wendzelnntpd.service_raw
 	sed -e 's|@sbindir[@]|$(sbindir)|g' $@_raw > $@
 
 create_certificate : Makefile $(srcdir)/create_certificate_raw
@@ -271,6 +274,7 @@ clean :
 	@# documentation cleanup
 	cd docs && $(MAKE) clean
 	rm -f $(srcdir)/scripts/startup/init.d_script
+	rm -f $(srcdir)/scripts/startup/wendzelnntpd.service
 	rm -f $(srcdir)/docs/create_certificate.8
 	rm -f $(srcdir)/create_certificate
 	rm -f $(srcdir)/wendzelnntpd.conf

--- a/Makefile.in
+++ b/Makefile.in
@@ -271,6 +271,9 @@ clean :
 	@# documentation cleanup
 	cd docs && $(MAKE) clean
 	rm -f $(srcdir)/scripts/startup/init.d_script
+	rm -f $(srcdir)/docs/create_certificate.8
+	rm -f $(srcdir)/create_certificate
+	rm -f $(srcdir)/wendzelnntpd.conf
 
 print_version :
 	@echo "$(PACKAGE_VERSION) $(RELEASENAME)"

--- a/docs/docs/install.md
+++ b/docs/docs/install.md
@@ -78,10 +78,11 @@ with the parameter `--targetdir`. You also need to adjust the paths in
 *wendzelnntpd.conf* if you use a non-default location
 (check Section [Encrypted connections over TLS](configuration.md#encrypted-connections-over-tls)).
 
-### Init Script for Automatic Startup
+### Automatic startup
 
-There is an init script in the directory scripts/startup. It uses the
-usual parameters like "start", "stop" and "restart".
+There is an init script and a systemd service unit in the directory scripts/startup for automatic
+startup of `wendzelnntpd`. More information can be found in
+[Automating Start, Stop, and Restart](running.md#automating-start-stop-and-restart)
 
 ## Docker image for Linux
 

--- a/docs/docs/running.md
+++ b/docs/docs/running.md
@@ -28,6 +28,8 @@ To restart the service, terminate and start the service.
 
 ### Automating Start, Stop, and Restart
 
+#### init.d script
+
 The script **init.d_script** in the directory *scripts/startup* of the
 tarball can be used to start, restart, and stop WendzelNNTPd. It is a
 standard *init.d* script for Linux operating systems that can usually be
@@ -56,6 +58,43 @@ WendzelNNTPd: version 2.0.7 'Berlin'  - (Oct 26 2015 14:10:20 #2544) is ready.
 
 $ /etc/init.d/wendzelnntpd stop
 Stopping WendzelNNTPd ... done.
+```
+
+#### systemd service unit
+
+The project also includes a systemd service unit file that can be used
+to start, stop, and restart wendzelnntpd on systems which use systemd as their init system.
+The file can be found in under *scripts/startup/wendzelnntpd.service* after building the
+project with `make`.
+You can install it by copying it to */etc/systemd/system* and then
+reloading the unit files:
+```console
+$ sudo cp scripts/startup/wendzelnntpd.service /etc/systemd/system/
+$ sudo systemctl daemon-reload
+```
+
+To start, stop, and restart WendzelNNTPd, to enable and disable the service and to show the status,
+the following commands can be used afterwards:
+```console
+$ sudo systemctl start wendzelnntpd.service
+$ sudo systemctl status wendzelnntpd
+wendzelnntpd.service - WendzelNNTPd Usenet server
+     Loaded: loaded (/etc/systemd/system/wendzelnntpd.service; enabled; preset: enabled)
+     Active: active (running) since Sat 2025-09-27 21:25:30 CEST; 1min 11s ago
+       Docs: man:wendzelnntpd(8)
+   Main PID: 105845 (wendzelnntpd)
+      Tasks: 1 (limit: 38345)
+     Memory: 1.5M
+        CPU: 1min 11.173s
+     CGroup: /system.slice/wendzelnntpd.service
+...
+$ sudo systemctl restart wendzelnntp
+$ sudo systemctl stop wendzelnntpd
+$ sudo systemctl enable wendzelnntpd
+Created symlink /etc/systemd/system/multi-user.target.wants/wendzelnntpd.service 
+    → /etc/systemd/system/wendzelnntpd.service.
+$ sudo systemctl disable wendzelnntpd
+Removed "/etc/systemd/system/multi-user.target.wants/wendzelnntpd.service".
 ```
 
 ## Administration Tool 'wendzelnntpadm'

--- a/scripts/startup/wendzelnntpd.service_raw
+++ b/scripts/startup/wendzelnntpd.service_raw
@@ -1,0 +1,11 @@
+[Unit]
+Description=WendzelNNTPd Usenet server
+Documentation=man:wendzelnntpd(8)
+After=network.target
+
+[Service]
+Type=simple
+ExecStart=@sbindir@/wendzelnntpd
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
This PR adds an systemd service unit for wendzelnntpd to make it possible to start/restart/stop wendzelnntpd with systemd on systems which use systemd as their init system. A new chapter regarding the systemd service unit is added to the documentation.
The also adds the removal of some files to the make clean target, which are generated by make.